### PR TITLE
fix(public): make slug-collision precedence fixture self-contained

### DIFF
--- a/modules/public/tests/public.docs.integration.tests.js
+++ b/modules/public/tests/public.docs.integration.tests.js
@@ -171,7 +171,27 @@ describe('Public docs integration tests — slug-collision precedence:', () => {
     fs.writeFileSync(reverseFixtureAbsPath, '# App Quickstart\n\nApplication-level quickstart guide.\n');
     reverseGuideRelPath = path.relative(process.cwd(), reverseFixtureAbsPath);
 
-    config.files.guides = [...originalGuides, appGuidePath, reverseGuideRelPath];
+    // The block fully controls its own input — no `...originalGuides` spread.
+    // Spreading the real on-disk `config.files.guides` implicitly assumed at
+    // most one real guide per slug (the framework's own `modules/home/`); a
+    // downstream consumer shipping a second real guide at the same slug from
+    // its own (non-core) module lands at the SAME precedence tier as this
+    // fixture and silently wins the same-tier tiebreak, defeating the test
+    // (#4012). The two framework sample guides these fixtures collide
+    // against are listed explicitly instead, by their known real path — both
+    // cross-tier assertions below need a framework guide actually present
+    // (as the silently-losing incumbent for "welcome", the explicitly
+    // overridden incumbent for "quickstart"), so removing the spread can't
+    // also drop them.
+    const frameworkWelcomeGuide = 'modules/home/doc/guides/00-welcome.md';
+    const frameworkQuickstartGuide = 'modules/home/doc/guides/01-quickstart.md';
+
+    config.files.guides = [
+      frameworkWelcomeGuide,
+      frameworkQuickstartGuide,
+      appGuidePath,
+      reverseGuideRelPath,
+    ];
   });
 
   afterAll(async () => {


### PR DESCRIPTION
## Summary

- What changed: In the "slug-collision precedence" describe block (`modules/public/tests/public.docs.integration.tests.js`), the fixture's `config.files.guides` input no longer extends the real on-disk guide list (`...originalGuides` spread removed). It now uses an explicit list: the two known framework guide paths (`modules/home/doc/guides/00-welcome.md`, `modules/home/doc/guides/01-quickstart.md`) plus the fixture's own two synthetic guide paths.
- Why: The old fixture built its input by spreading `originalGuides` — the real, on-disk `config.files.guides` — which implicitly assumed at most one real guide per slug (the framework's own `modules/home/`). A downstream consumer that ships a second real guide at the same slug from its own module lands at the same precedence tier as the fixture and silently wins the same-tier tiebreak in `resolveGuideEntries`, defeating this test deterministically in that consumer's CI — even though production precedence behavior is correct. Removing the spread makes the block fully control its own input, independent of any downstream repo's real on-disk guide state.
- Related issues: Closes #4012

## Scope

- Module(s) impacted: `public` (tests only)
- Cross-module impact: `none`
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm test`
- [ ] Manual checks done (if applicable)

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: none — test-file-only change, no source files touched, no assertions changed.
- Mergeability considerations: this is the fix motivated by the fixture-collision scenario described in #4012; it makes the stack's own test suite independent of a downstream consumer's real on-disk guide content.
- Follow-up tasks (optional): none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved slug-collision test coverage by explicitly including framework and fixture guides.
  * Added documentation clarifying expected precedence when guides share the same slug.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->