### PR TITLE
fix(billing): surface live cancelAt through getSubscription

### DIFF
--- a/modules/billing/services/billing.service.js
+++ b/modules/billing/services/billing.service.js
@@ -338,6 +338,7 @@ const fetchSubscriptionDetails = async (stripeSubscriptionId) => {
     currentPeriodStart: new Date(rawPeriodStart * 1000),
     currentPeriodEnd: new Date(rawPeriodEnd * 1000),
     cancelAtPeriodEnd: stripeSub.cancel_at_period_end,
+    cancelAt,
     status: stripeSub.status,
     nextRenewalDate: cancelAt ?? new Date(rawPeriodEnd * 1000),
   };

--- a/modules/billing/tests/billing.checkout.unit.tests.js
+++ b/modules/billing/tests/billing.checkout.unit.tests.js
@@ -746,6 +746,44 @@ describe('Billing service unit tests:', () => {
       expect(mockStripeInstance.subscriptions.retrieve).toHaveBeenCalledWith('sub_456');
     });
 
+    test('should override a stale persisted cancelAt with the live value on reactivation', async () => {
+      // A prior webhook persisted a cancellation date. The subscription was since
+      // reactivated in Stripe (cancel_at cleared), but the DB copy still carries
+      // the stale date. getSubscription must surface the live (null) value, not
+      // the stale persisted one — same freshness treatment as cancelAtPeriodEnd.
+      jest.unstable_mockModule('../../../config/index.js', () => ({
+        default: { stripe: { secretKey: 'sk_test_sub_reactivate' } },
+      }));
+
+      const periodEnd = Math.floor(Date.now() / 1000) + 86400;
+      mockStripeInstance.subscriptions = {
+        retrieve: jest.fn().mockResolvedValue({
+          current_period_start: periodEnd - 2592000,
+          current_period_end: periodEnd,
+          cancel_at_period_end: false,
+          status: 'active',
+          cancel_at: null,
+        }),
+      };
+
+      const staleCancelAt = new Date(Date.now() + 3600 * 1000);
+      const mockSub = {
+        organization: orgId,
+        plan: 'pro',
+        stripeSubscriptionId: 'sub_reactivated',
+        cancelAt: staleCancelAt,
+        toJSON: () => ({ organization: orgId, plan: 'pro', stripeSubscriptionId: 'sub_reactivated', cancelAt: staleCancelAt }),
+      };
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue(mockSub);
+
+      const mod = await import('../services/billing.service.js');
+      BillingService = mod.default;
+
+      const result = await BillingService.getSubscription(orgId);
+
+      expect(result.cancelAt).toBeNull();
+    });
+
     test('should return cached sub without Stripe fetch when no stripeSubscriptionId (free plan)', async () => {
       jest.unstable_mockModule('../../../config/index.js', () => ({
         default: { stripe: { secretKey: 'sk_test_sub_free' } },


### PR DESCRIPTION
## Summary

- What changed: `fetchSubscriptionDetails` now includes the already-computed `cancelAt` in the object it returns, so `getSubscription`'s merge overrides the persisted (DB) value with the live Stripe value — the same freshness treatment `cancelAtPeriodEnd` and `currentPeriodEnd` already receive.
- Why: `getSubscription` merges a **live** `cancelAtPeriodEnd` with a **stale, DB-only** `cancelAt` written by the last webhook. Stripe represents a portal cancellation as `cancel_at` + `canceled_at` + a cancellation reason, leaving `cancel_at_period_end` false — so a consumer reading `cancelAt` for "this subscription is ending" sees a value Stripe already cleared after a reactivation, until the next webhook lands (or indefinitely if it's dropped/out of order).
- Related issues: Closes #4022

## Scope

- Module(s) impacted: `billing`
- Cross-module impact: `none`
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm test`
- [x] Manual checks done (if applicable)

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: none — read-path only, no new state or schema change.
- Mergeability considerations: none — single field addition, no signature change.
- Follow-up tasks (optional): none.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Subscription details now accurately reflect the cancellation date from the payment provider.
  * Reactivated subscriptions no longer display an outdated cancellation date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->