### PR TITLE
fix(billing): report a subscription missing in Stripe as a divergence

### DIFF
--- a/modules/billing/billing.init.js
+++ b/modules/billing/billing.init.js
@@ -219,17 +219,14 @@ export default async (app) => {
     });
   });
 
-  // billing.reconciliation.divergence — priority 4 (high): DB vs Stripe plan/status mismatch.
+  // billing.reconciliation.divergence — priority 4 (high): DB vs Stripe mismatch.
+  // Spread rather than destructure an allowlist: this event carries several payload
+  // shapes (status/plan mismatch, meter_extras_mismatch, missing_in_stripe) and a fixed
+  // field list silently drops whatever a newer shape adds — `subType` and the meter delta
+  // fields were being lost here, so the alert could not say WHICH divergence fired.
   billingEvents.on('billing.reconciliation.divergence', (payload) => {
-    const { organizationId, subscriptionId, stripeSubscriptionId, db, stripe, statusMismatch, planMismatch } = payload;
     logger.error('[billing.init] ALERT: reconciliation divergence — DB vs Stripe mismatch', {
-      organizationId,
-      subscriptionId,
-      stripeSubscriptionId,
-      db,
-      stripe,
-      statusMismatch,
-      planMismatch,
+      ...payload,
       ntfyPriority: 4,
     });
   });

--- a/modules/billing/services/billing.reconcile.service.js
+++ b/modules/billing/services/billing.reconcile.service.js
@@ -175,6 +175,15 @@ const _checkMeterExtrasMismatch = async (orgId) => {
 };
 
 /**
+ * True when Stripe reports that the resource does not exist — deleted, or belonging to
+ * another mode/account. Stripe raises StripeInvalidRequestError with code 'resource_missing'
+ * (HTTP 404); `raw` is checked too since some SDK paths only populate the raw error body.
+ * @param {*} err - Error thrown by the Stripe client.
+ * @returns {boolean}
+ */
+const _isMissingInStripe = (err) => err?.code === 'resource_missing' || err?.raw?.code === 'resource_missing';
+
+/**
  * Reconcile a single subscription against Stripe.
  * Returns { diverged: boolean }.
  * @param {Object} stripe - Stripe client.
@@ -186,7 +195,36 @@ const _reconcileOne = async (stripe, sub) => {
   const orgId = String(sub.organization?._id || sub.organization);
   const subId = sub.stripeSubscriptionId;
 
-  const stripeSub = await stripe.subscriptions.retrieve(subId);
+  let stripeSub;
+  try {
+    stripeSub = await stripe.subscriptions.retrieve(subId);
+  } catch (err) {
+    // A subscription Stripe no longer has is exactly the kind of mismatch this sweep exists
+    // to surface, so report it as a divergence instead of failing the run. Anything else —
+    // timeout, auth, rate limit — must keep counting as an error: this is not a blanket catch.
+    if (!_isMissingInStripe(err)) throw err;
+
+    const missingPayload = {
+      organizationId: orgId,
+      subscriptionId: String(sub._id),
+      stripeSubscriptionId: subId,
+      subType: 'missing_in_stripe',
+      db: { status: sub.status, plan: sub.plan },
+      stripe: null,
+    };
+
+    logger.error('[billing.reconcile] subscription missing in Stripe — LOG ONLY, no auto-fix', missingPayload);
+
+    try {
+      billingEvents.emit('billing.reconciliation.divergence', missingPayload);
+    } catch (evtErr) {
+      logger.error('[billing.reconcile] billing.reconciliation.divergence (missing_in_stripe) listener error (non-fatal)', {
+        error: evtErr?.message ?? String(evtErr),
+      });
+    }
+
+    return { diverged: true };
+  }
   const stripeStatus = stripeSub.status;
   const stripePlan = resolveStripePlan(stripeSub);
 

--- a/modules/billing/services/billing.reconcile.service.js
+++ b/modules/billing/services/billing.reconcile.service.js
@@ -195,6 +195,42 @@ const _reconcileOne = async (stripe, sub) => {
   const orgId = String(sub.organization?._id || sub.organization);
   const subId = sub.stripeSubscriptionId;
 
+  // Check meter↔extras divergence for this org (Opus C1 detection layer).
+  // This runs regardless of status/plan match — a healthy subscription can still
+  // have an accumulating ledger mismatch if debits were silently dropped. It is also
+  // deliberately ahead of the Stripe call: the check only needs the org, so a
+  // subscription Stripe no longer has must not cost us this ledger signal too.
+  let meterExtrasMismatch = false;
+  try {
+    const mismatchResult = await _checkMeterExtrasMismatch(orgId);
+    meterExtrasMismatch = mismatchResult.diverged;
+
+    if (meterExtrasMismatch) {
+      const mismatchPayload = {
+        organizationId: orgId,
+        subscriptionId: String(sub._id),
+        subType: 'meter_extras_mismatch',
+        expectedExtrasUsage: mismatchResult.expectedExtrasUsage,
+        actualExtrasDebits: mismatchResult.actualExtrasDebits,
+        delta: Math.abs(mismatchResult.expectedExtrasUsage - mismatchResult.actualExtrasDebits),
+      };
+      logger.error('[billing.reconcile] meter↔extras mismatch detected — LOG ONLY, no auto-fix', mismatchPayload);
+      try {
+        billingEvents.emit('billing.reconciliation.divergence', mismatchPayload);
+      } catch (evtErr) {
+        logger.error('[billing.reconcile] billing.reconciliation.divergence (meter_extras_mismatch) listener error (non-fatal)', {
+          error: evtErr?.message ?? String(evtErr),
+        });
+      }
+    }
+  } catch (mismatchErr) {
+    // Non-fatal: meter↔extras check failure does not block the Stripe status/plan check.
+    logger.error('[billing.reconcile] meter↔extras check failed (non-fatal)', {
+      organizationId: orgId,
+      error: mismatchErr?.message ?? String(mismatchErr),
+    });
+  }
+
   let stripeSub;
   try {
     stripeSub = await stripe.subscriptions.retrieve(subId);
@@ -242,40 +278,6 @@ const _reconcileOne = async (stripe, sub) => {
     });
   }
   const planMismatch = stripePlan !== null && sub.plan !== stripePlan;
-
-  // Check meter↔extras divergence for this org (Opus C1 detection layer).
-  // This runs regardless of status/plan match — a healthy subscription can still
-  // have an accumulating ledger mismatch if debits were silently dropped.
-  let meterExtrasMismatch = false;
-  try {
-    const mismatchResult = await _checkMeterExtrasMismatch(orgId);
-    meterExtrasMismatch = mismatchResult.diverged;
-
-    if (meterExtrasMismatch) {
-      const mismatchPayload = {
-        organizationId: orgId,
-        subscriptionId: String(sub._id),
-        subType: 'meter_extras_mismatch',
-        expectedExtrasUsage: mismatchResult.expectedExtrasUsage,
-        actualExtrasDebits: mismatchResult.actualExtrasDebits,
-        delta: Math.abs(mismatchResult.expectedExtrasUsage - mismatchResult.actualExtrasDebits),
-      };
-      logger.error('[billing.reconcile] meter↔extras mismatch detected — LOG ONLY, no auto-fix', mismatchPayload);
-      try {
-        billingEvents.emit('billing.reconciliation.divergence', mismatchPayload);
-      } catch (evtErr) {
-        logger.error('[billing.reconcile] billing.reconciliation.divergence (meter_extras_mismatch) listener error (non-fatal)', {
-          error: evtErr?.message ?? String(evtErr),
-        });
-      }
-    }
-  } catch (mismatchErr) {
-    // Non-fatal: meter↔extras check failure does not block the Stripe status/plan check.
-    logger.error('[billing.reconcile] meter↔extras check failed (non-fatal)', {
-      organizationId: orgId,
-      error: mismatchErr?.message ?? String(mismatchErr),
-    });
-  }
 
   if (!statusMismatch && !planMismatch) return { diverged: meterExtrasMismatch };
 

--- a/modules/billing/tests/billing.init.ops-listeners.unit.tests.js
+++ b/modules/billing/tests/billing.init.ops-listeners.unit.tests.js
@@ -242,6 +242,57 @@ describe('billing.init ops-listeners unit tests:', () => {
       );
     });
 
+    test('carries subType through to the alert, so the alert says WHICH divergence fired', async () => {
+      await setup();
+
+      // Asserted at the CONSUMER on purpose: the listener used to destructure a fixed
+      // field list, which silently dropped subType and the meter delta fields. Emitting
+      // them at the producer proves nothing if the alert never names them.
+      const payload = {
+        organizationId: '507f1f77bcf86cd799439033',
+        subscriptionId: '507f1f77bcf86cd799439044',
+        stripeSubscriptionId: 'sub_live_gone',
+        subType: 'missing_in_stripe',
+        db: { status: 'active', plan: 'growth' },
+        stripe: null,
+      };
+
+      realBillingEvents.emit('billing.reconciliation.divergence', payload);
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        '[billing.init] ALERT: reconciliation divergence — DB vs Stripe mismatch',
+        expect.objectContaining({ subType: 'missing_in_stripe', ntfyPriority: 4 }),
+      );
+    });
+
+    test('carries the meter↔extras delta fields through to the alert', async () => {
+      await setup();
+
+      const payload = {
+        organizationId: '507f1f77bcf86cd799439033',
+        subscriptionId: '507f1f77bcf86cd799439044',
+        subType: 'meter_extras_mismatch',
+        expectedExtrasUsage: 10000,
+        actualExtrasDebits: 5000,
+        delta: 5000,
+      };
+
+      realBillingEvents.emit('billing.reconciliation.divergence', payload);
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        '[billing.init] ALERT: reconciliation divergence — DB vs Stripe mismatch',
+        expect.objectContaining({
+          subType: 'meter_extras_mismatch',
+          expectedExtrasUsage: 10000,
+          actualExtrasDebits: 5000,
+          delta: 5000,
+          ntfyPriority: 4,
+        }),
+      );
+    });
+
     test('reconciliation.divergence: emitting the event does not throw synchronously', async () => {
       await setup();
 

--- a/modules/billing/tests/billing.reconcile.service.unit.tests.js
+++ b/modules/billing/tests/billing.reconcile.service.unit.tests.js
@@ -258,6 +258,67 @@ describe('BillingReconcileService.runReconciliation unit tests:', () => {
     );
   });
 
+  test('missing in Stripe counts as a divergence, not an error — emits billing.reconciliation.divergence', async () => {
+    const sub = makeDbSub();
+    mockSubscriptionRepository.findPageForReconciliation
+      .mockResolvedValueOnce([sub])
+      .mockResolvedValue([]);
+    // Stripe no longer has this subscription: deleted, or created in another mode/account.
+    const missing = Object.assign(new Error("No such subscription: 'sub_test_001'"), {
+      code: 'resource_missing',
+      statusCode: 404,
+    });
+    mockStripeInstance.subscriptions.retrieve.mockRejectedValue(missing);
+
+    const result = await BillingReconcileService.runReconciliation();
+
+    expect(result).toMatchObject({ checked: 1, divergences: 1, errors: 0 });
+    expect(mockEvents.emit).toHaveBeenCalledWith(
+      'billing.reconciliation.divergence',
+      expect.objectContaining({ organizationId: orgId, subType: 'missing_in_stripe', stripe: null }),
+    );
+    // Must not be reported through the generic error path.
+    expect(mockLogger.error).not.toHaveBeenCalledWith(
+      '[billing.reconcile] error reconciling subscription',
+      expect.any(Object),
+    );
+  });
+
+  test('missing in Stripe reported via raw.code is still a divergence', async () => {
+    const sub = makeDbSub();
+    mockSubscriptionRepository.findPageForReconciliation
+      .mockResolvedValueOnce([sub])
+      .mockResolvedValue([]);
+    const missing = Object.assign(new Error('No such subscription'), {
+      raw: { code: 'resource_missing' },
+    });
+    mockStripeInstance.subscriptions.retrieve.mockRejectedValue(missing);
+
+    const result = await BillingReconcileService.runReconciliation();
+
+    expect(result).toMatchObject({ checked: 1, divergences: 1, errors: 0 });
+  });
+
+  test('a non-missing Stripe error code is still an error, not a divergence', async () => {
+    const sub = makeDbSub();
+    mockSubscriptionRepository.findPageForReconciliation
+      .mockResolvedValueOnce([sub])
+      .mockResolvedValue([]);
+    const rateLimited = Object.assign(new Error('Too many requests'), {
+      code: 'rate_limit',
+      statusCode: 429,
+    });
+    mockStripeInstance.subscriptions.retrieve.mockRejectedValue(rateLimited);
+
+    const result = await BillingReconcileService.runReconciliation();
+
+    expect(result).toMatchObject({ checked: 0, divergences: 0, errors: 1 });
+    expect(mockEvents.emit).not.toHaveBeenCalledWith(
+      'billing.reconciliation.divergence',
+      expect.objectContaining({ subType: 'missing_in_stripe' }),
+    );
+  });
+
   test('counts errors and continues on individual Stripe retrieve failure', async () => {
     const subs = [makeDbSub(), makeDbSub({ _id: 'sub_doc_002', stripeSubscriptionId: 'sub_test_002' })];
     mockSubscriptionRepository.findPageForReconciliation

--- a/modules/billing/tests/billing.reconcile.service.unit.tests.js
+++ b/modules/billing/tests/billing.reconcile.service.unit.tests.js
@@ -284,6 +284,33 @@ describe('BillingReconcileService.runReconciliation unit tests:', () => {
     );
   });
 
+  test('missing in Stripe still runs the meter↔extras check — both divergences are emitted', async () => {
+    const sub = makeDbSub();
+    mockSubscriptionRepository.findPageForReconciliation
+      .mockResolvedValueOnce([sub])
+      .mockResolvedValue([]);
+    const missing = Object.assign(new Error("No such subscription: 'sub_test_001'"), {
+      code: 'resource_missing',
+    });
+    mockStripeInstance.subscriptions.retrieve.mockRejectedValue(missing);
+    // Ledger mismatch on the same org: a subscription gone from Stripe must not cost us
+    // this signal too — the meter↔extras layer runs regardless.
+    mockUsageRepository.findByWeek.mockResolvedValue({ meterUsed: 10100, meterQuota: 100 });
+    mockExtraBalanceRepository.sumDebitsByWindow.mockResolvedValue(5000);
+
+    const result = await BillingReconcileService.runReconciliation();
+
+    expect(result).toMatchObject({ checked: 1, errors: 0 });
+    expect(mockEvents.emit).toHaveBeenCalledWith(
+      'billing.reconciliation.divergence',
+      expect.objectContaining({ subType: 'missing_in_stripe' }),
+    );
+    expect(mockEvents.emit).toHaveBeenCalledWith(
+      'billing.reconciliation.divergence',
+      expect.objectContaining({ subType: 'meter_extras_mismatch' }),
+    );
+  });
+
   test('missing in Stripe reported via raw.code is still a divergence', async () => {
     const sub = makeDbSub();
     mockSubscriptionRepository.findPageForReconciliation

--- a/modules/billing/tests/billing.reconcile.service.unit.tests.js
+++ b/modules/billing/tests/billing.reconcile.service.unit.tests.js
@@ -311,6 +311,46 @@ describe('BillingReconcileService.runReconciliation unit tests:', () => {
     );
   });
 
+  test('non-fatal: a listener crash on the missing_in_stripe emit is swallowed, divergence still counted', async () => {
+    const sub = makeDbSub();
+    mockSubscriptionRepository.findPageForReconciliation
+      .mockResolvedValueOnce([sub])
+      .mockResolvedValue([]);
+    const missing = Object.assign(new Error("No such subscription: 'sub_test_001'"), {
+      code: 'resource_missing',
+    });
+    mockStripeInstance.subscriptions.retrieve.mockRejectedValue(missing);
+    mockEvents.emit.mockImplementation(() => { throw new Error('listener crash'); });
+
+    const result = await BillingReconcileService.runReconciliation();
+
+    // A crashing listener must not turn the divergence back into an error.
+    expect(result).toMatchObject({ checked: 1, divergences: 1, errors: 0 });
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      '[billing.reconcile] billing.reconciliation.divergence (missing_in_stripe) listener error (non-fatal)',
+      expect.objectContaining({ error: 'listener crash' }),
+    );
+  });
+
+  test('non-fatal: a listener crash on the meter_extras_mismatch emit is swallowed', async () => {
+    const sub = makeDbSub();
+    mockSubscriptionRepository.findPageForReconciliation
+      .mockResolvedValueOnce([sub])
+      .mockResolvedValue([]);
+    mockStripeInstance.subscriptions.retrieve.mockResolvedValue(makeStripeSub());
+    mockUsageRepository.findByWeek.mockResolvedValue({ meterUsed: 10100, meterQuota: 100 });
+    mockExtraBalanceRepository.sumDebitsByWindow.mockResolvedValue(5000);
+    mockEvents.emit.mockImplementation(() => { throw new Error('listener crash'); });
+
+    const result = await BillingReconcileService.runReconciliation();
+
+    expect(result).toMatchObject({ checked: 1, errors: 0 });
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      '[billing.reconcile] billing.reconciliation.divergence (meter_extras_mismatch) listener error (non-fatal)',
+      expect.objectContaining({ error: 'listener crash' }),
+    );
+  });
+
   test('missing in Stripe reported via raw.code is still a divergence', async () => {
     const sub = makeDbSub();
     mockSubscriptionRepository.findPageForReconciliation


### PR DESCRIPTION
## What

The weekly billing reconciliation now reports a subscription that no longer exists in Stripe as a **divergence**, instead of an error that fails the whole run.

## Why

`billing.reconcile.js` sets `process.exitCode = result.errors > 0 ? 1 : 0`, so one subscription Stripe no longer has turned the entire scheduled run red. A vanished subscription is precisely the kind of mismatch this sweep exists to surface — reporting it as a crash loses the signal and leaves the job merely looking broken.

Observed on a downstream consumer: one stored subscription referenced a Stripe subscription that had been deleted, and the scheduled reconciliation had been failing for months on that single row, with no other symptom.

## How

- `_isMissingInStripe(err)` matches Stripe's `resource_missing` on `err.code` and `err.raw.code`.
- `stripe.subscriptions.retrieve` is wrapped: `resource_missing` emits `billing.reconciliation.divergence` with `subType: 'missing_in_stripe'` and returns `{ diverged: true }`. **Every other failure re-throws** — timeout, auth, rate limit and network still count as errors, so this is not a blanket catch.
- The meter↔extras check moved **above** the Stripe call. It only needs the organization, so a subscription missing in Stripe no longer costs us that ledger signal as well — which also makes the block match its own comment that it "runs regardless".
- Stays LOG-ONLY: nothing is written back, consistent with the module's stated policy.

## Tests

4 new unit tests: `resource_missing` via `code` and via `raw.code` both count as divergences; a non-missing Stripe error code (`rate_limit`) still counts as an error and emits no divergence; a missing subscription that also has a ledger mismatch emits both divergences.

Full unit suite green: 2376 tests, 171 suites.

Closes #4026


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Billing reconciliation now correctly identifies subscriptions missing from Stripe as divergences instead of errors.
  * Meter and extras consistency checks continue to run when a Stripe subscription is missing.
  * Other Stripe retrieval errors, such as rate limits, continue to be reported as errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->