### PR TITLE
fix(deps): bump js-yaml to 4.3.2 to close CVE-2026-59870

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "handlebars": "^4.7.9",
         "helmet": "~8.2.0",
         "inquirer": "^14.0.2",
-        "js-yaml": "^4.2.0",
+        "js-yaml": "^4.3.2",
         "jsonwebtoken": "^9.0.3",
         "lodash": "^4.18.1",
         "lusca": "^1.7.0",
@@ -13575,9 +13575,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "handlebars": "^4.7.9",
     "helmet": "~8.2.0",
     "inquirer": "^14.0.2",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.2",
     "jsonwebtoken": "^9.0.3",
     "lodash": "^4.18.1",
     "lusca": "^1.7.0",


### PR DESCRIPTION
## What

Bumps `js-yaml` from 4.2.0 to 4.3.2. Lockfile + manifest only, no source change.

## Why

Two high-severity Dependabot alerts are open against the **runtime** scope:

| Advisory | Vulnerable range | Fixed in |
|---|---|---|
| Quadratic CPU consumption in `!!omap` resolution (CVE-2026-59870) | `>= 4.0.0, < 4.3.1` | 4.3.1 |
| YAML merge-key chains force quadratic CPU consumption | `>= 4.0.0, < 4.3.0` | 4.3.0 |

Runtime scope is correct: `lib/services/express.js` parses the OpenAPI spec with `js-yaml` at boot.

## Why 4.3.2 and not 5.x

Dependabot proposed #3909 (4.2.0 -> 5.1.0) for the same alerts, but that PR is red and cannot ship as-is:

- v5 removes the ESM `default` export. `lib/services/express.js:17` and `modules/tasks/tests/tasks.openapi-operationid.unit.tests.js:2` both use `import YAML from 'js-yaml'`, so v5 breaks **application boot**, not only tests (`lib/app.js` imports `express.js`).
- v5 also switches `load()` from `DEFAULT_SCHEMA` to `CORE_SCHEMA` (no `!!merge` by default) and makes `load('')` throw — a behaviour change on the exact code path that serves the OpenAPI docs.

4.3.2 is inside the existing `^4.2.0` range, closes both advisories, and needs no migration. The v5 move stays a separate, deliberate decision.

Refs #3909

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the YAML parsing dependency to a newer version for improved maintenance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->