### PR TITLE
feat(responses): expose whitelisted AppError details in the production error envelope

### DIFF
--- a/config/defaults/development.config.js
+++ b/config/defaults/development.config.js
@@ -126,6 +126,19 @@ const config = {
     p3p: 'ABCDEF',
     xssProtection: true,
   },
+  // errors: {
+  //   Whitelist extension point (optional — intentionally OMITTED here, same
+  //   reasoning as log.sensitiveQueryKeys/log.sensitivePathMarkers above): a
+  //   module or downstream project config may set `errors.detailsWhitelist`
+  //   (array of exact AppError.details key names) to ADD its own
+  //   production-safe keys to the built-in list consumed by
+  //   `lib/helpers/responses.js` (['upgradeUrl', 'type', 'retryAfter']).
+  //   Values are UNIONED with the built-ins, never replacing them — declaring
+  //   a base array here would let `deepMerge` clobber a Layer-1 module
+  //   extension wholesale instead of adding to it. Opt-in only: a key not on
+  //   this list stays dev-only, exactly as before.
+  //   detailsWhitelist: ['aDownstreamSafeKey'],
+  // },
   bodyParser: {
     limit: '500kb',
   },

--- a/config/index.js
+++ b/config/index.js
@@ -9,6 +9,7 @@ import objectPath from 'object-path';
 import { pathToFileURL } from 'url';
 import assets from './assets.js';
 import configHelper from '../lib/helpers/config.js';
+import UNSAFE_KEYS from '../lib/helpers/unsafeKeys.js';
 
 const STANDARD_ENVS = new Set(['development', 'production', 'test']);
 
@@ -26,12 +27,12 @@ const assertSafeEnv = (env) => {
 
 /**
  * Deep merge two objects, replacing arrays instead of merging by index.
+ * Skips `UNSAFE_KEYS` (`../lib/helpers/unsafeKeys.js`) so a config source
+ * object can never repoint `target`'s prototype via a `__proto__` key.
  * @param {Object} target - Base object
  * @param {Object} source - Override object
  * @returns {Object} Merged result (new object, inputs are not mutated)
  */
-const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
-
 const deepMerge = (target, source) => {
   const result = { ...target };
   for (const key of Object.keys(source)) {

--- a/lib/helpers/responses.js
+++ b/lib/helpers/responses.js
@@ -141,8 +141,19 @@ const pickWhitelistedDetails = (details, whitelist = DETAILS_WHITELIST) => {
   const picked = Object.create(null);
   for (const key of whitelist) {
     if (!Object.prototype.hasOwnProperty.call(details, key)) continue;
-    const value = details[key];
-    if (isSafeDetailValue(value)) picked[key] = value;
+    // A whitelisted key may be backed by a throwing getter (e.g. `details`
+    // built from a raw caught exception whose accessor reads a closed
+    // resource). Reading it must never propagate out of the picker — that
+    // would abort the whole response instead of just dropping this one key
+    // — and must never stop the loop from picking the remaining whitelisted
+    // keys. Fail closed and stay silent-safe: same "drop this key" contract
+    // as every other unsafe shape handled by `isSafeDetailValue`.
+    try {
+      const value = details[key];
+      if (isSafeDetailValue(value)) picked[key] = value;
+    } catch (_err) {
+      // Drop this key only; continue with the rest of the whitelist.
+    }
   }
   return Object.keys(picked).length > 0 ? picked : undefined;
 };
@@ -257,4 +268,9 @@ export default {
 // Pure helpers exported for direct unit testing — see `pickWhitelistedDetails`
 // and `buildWhitelist` doc comments above for why (belt-and-braces
 // null-prototype defense, and config-widening without `jest.resetModules()`).
-export { buildWhitelist, pickWhitelistedDetails, isSafeDetailValue };
+// `isSafeDetailValue` is intentionally NOT exported: nothing calls it
+// directly, its branches are already exercised indirectly through
+// `pickWhitelistedDetails`/`responses.error` (see the "whitelisted details
+// value validation" describe block), and this stack keeps a module's public
+// surface limited to what something outside it actually needs.
+export { buildWhitelist, pickWhitelistedDetails };

--- a/lib/helpers/responses.js
+++ b/lib/helpers/responses.js
@@ -45,7 +45,7 @@ const DEFAULT_DETAILS_WHITELIST = ['upgradeUrl', 'type', 'retryAfter'];
  * dropped silently, never included and never crashes boot.
  * @param {*} value - the raw `config.errors.detailsWhitelist` value
  * @param {String} label - dotted config path for the warning message
- * @return {Array} the sanitized, per-element-safe list; `[]` for a malformed whole value
+ * @returns {Array} the sanitized, per-element-safe list; `[]` for a malformed whole value
  */
 const sanitizeConfigList = (value, label) => {
   if (Array.isArray(value)) {
@@ -65,7 +65,7 @@ const sanitizeConfigList = (value, label) => {
  * filtering — is directly unit-testable without `jest.resetModules()`
  * gymnastics.
  * @param {*} configValue - the raw `config.errors.detailsWhitelist` value
- * @return {Set<String>} the built-in defaults unioned with the sanitized config extension
+ * @returns {Set<String>} the built-in defaults unioned with the sanitized config extension
  */
 const buildWhitelist = (configValue) => new Set([...DEFAULT_DETAILS_WHITELIST, ...sanitizeConfigList(configValue, 'errors.detailsWhitelist')]);
 
@@ -107,7 +107,7 @@ const MAX_DETAIL_VALUE_LENGTH = 200; // generous for a real upgradeUrl path or a
  * into the production error envelope. See `MAX_DETAIL_VALUE_LENGTH` doc above
  * for the exact safe shape and the reasoning behind it.
  * @param {*} value - the value found at a whitelisted key
- * @return {boolean} true when `value` is a safe scalar
+ * @returns {boolean} true when `value` is a safe scalar
  */
 const isSafeDetailValue = (value) => {
   if (value === null || typeof value === 'boolean') return true;
@@ -134,7 +134,7 @@ const isSafeDetailValue = (value) => {
  * never reassign its prototype ahead of `JSON.stringify`.
  * @param {*} details - `AppError.details`, in whatever shape the throw site built it
  * @param {Set<String>} [whitelist] - keys to match; defaults to the module's `DETAILS_WHITELIST`
- * @return {Object|undefined} whitelisted key/value pairs (a null-prototype object), or `undefined` when none matched
+ * @returns {Object|undefined} whitelisted key/value pairs (a null-prototype object), or `undefined` when none matched
  */
 const pickWhitelistedDetails = (details, whitelist = DETAILS_WHITELIST) => {
   if (!details || typeof details !== 'object' || Array.isArray(details)) return undefined;
@@ -233,7 +233,7 @@ const safeStringify = (value) => {
  * @param {number} httpStatus - HTTP status code or candidate error status
  * @param {string} message - Error message to send to the client
  * @param {string} description - Optional detailed error description
- * @return {Object} type, message, code, status, errorCode, description and (when
+ * @returns {Object} type, message, code, status, errorCode, description and (when
  *   any whitelisted key was present) details
  */
 const error = (res, httpStatus, message, description) => (error = {}) => {

--- a/lib/helpers/responses.js
+++ b/lib/helpers/responses.js
@@ -1,3 +1,4 @@
+import config from '../../config/index.js';
 import configHelper from './config.js';
 
 /**
@@ -10,6 +11,65 @@ const success = (res, message) => (data) => {
   const result = { type: 'success', message, data };
   res.status(200).json(result);
   return result;
+};
+
+/**
+ * Production-safe subset of `AppError.details` keys. Opt-in ONLY — a
+ * whitelist, never a denylist — so a key nobody thought to hide stays hidden
+ * by default instead of leaking by default. Matched by EXACT key name only
+ * (no prefix/suffix rule like "anything ending in Url"), so a future key such
+ * as an internal-only URL can never slip through by naming convention.
+ * @readonly
+ */
+const DEFAULT_DETAILS_WHITELIST = ['upgradeUrl', 'type', 'retryAfter'];
+
+/**
+ * @desc Sanitize a config-provided whitelist extension so a typo or wrong
+ * type can never crash boot or silently degrade into something unsafe.
+ * Mirrors `redactUrl.js#sanitizeConfigList` — same union-only contract.
+ * @param {*} value - the raw `config.errors.detailsWhitelist` value
+ * @param {String} label - dotted config path for the warning message
+ * @return {Array} `value` unchanged when it is already an array, otherwise `[]`
+ */
+const sanitizeConfigList = (value, label) => {
+  if (Array.isArray(value)) return value;
+  if (value == null) return [];
+  console.warn(`[responses] config.${label} ignored: expected an array, got ${typeof value}`);
+  return [];
+};
+
+/**
+ * Union of `DEFAULT_DETAILS_WHITELIST` and `config.errors.detailsWhitelist`: a
+ * downstream project ADDS its own production-safe detail keys from its own
+ * config, without patching this stack file. Deduplicated via `Set`. Missing
+ * config, a missing key, an explicit empty array, or a malformed (non-array)
+ * value all resolve to exactly the built-in defaults — config can only ever
+ * grow this set with keys the downstream project itself opts in, never turn
+ * it into a denylist and never remove a built-in entry.
+ */
+const DETAILS_WHITELIST = new Set([
+  ...DEFAULT_DETAILS_WHITELIST,
+  ...sanitizeConfigList(config?.errors?.detailsWhitelist, 'errors.detailsWhitelist'),
+]);
+
+/**
+ * @desc Pick the production-safe subset of `AppError.details` by EXACT key
+ * match against `DETAILS_WHITELIST`. Applies in every environment — there is
+ * nothing dev-only about it, it is a strict subset of what dev-grade envs
+ * already get via the full serialized-error blob below. Anything that is not
+ * a plain object (a bare string, the `[{ message }]` array AppError defaults
+ * to, `undefined`) has no own keys to match and yields no result, so the
+ * common case (no whitelisted key present) adds nothing to the envelope.
+ * @param {*} details - `AppError.details`, in whatever shape the throw site built it
+ * @return {Object|undefined} whitelisted key/value pairs, or `undefined` when none matched
+ */
+const pickWhitelistedDetails = (details) => {
+  if (!details || typeof details !== 'object' || Array.isArray(details)) return undefined;
+  const picked = {};
+  for (const key of DETAILS_WHITELIST) {
+    if (Object.prototype.hasOwnProperty.call(details, key)) picked[key] = details[key];
+  }
+  return Object.keys(picked).length > 0 ? picked : undefined;
 };
 
 /**
@@ -87,10 +147,12 @@ const safeStringify = (value) => {
  * @param {number} httpStatus - HTTP status code or candidate error status
  * @param {string} message - Error message to send to the client
  * @param {string} description - Optional detailed error description
- * @return {Object} type, message, code, status, errorCode and description
+ * @return {Object} type, message, code, status, errorCode, description and (when
+ *   any whitelisted key was present) details
  */
 const error = (res, httpStatus, message, description) => (error = {}) => {
   const status = getHttpStatus(httpStatus, error);
+  const whitelistedDetails = pickWhitelistedDetails(error.details);
   const result = {
     type: 'error',
     message: message || error.message || 'Something went wrong.',
@@ -98,6 +160,11 @@ const error = (res, httpStatus, message, description) => (error = {}) => {
     status,
     errorCode: getErrorCode(error),
     description: getDescription(description, error),
+    // Whitelisted details (e.g. billing's upgradeUrl/type) cross into every
+    // environment, production included — see DETAILS_WHITELIST above. Only
+    // added when at least one key matched, so most error responses are
+    // unaffected.
+    ...(whitelistedDetails ? { details: whitelistedDetails } : {}),
   };
   // Only expose the serialized raw error in dev-grade envs (development/test/local).
   // Any other NODE_ENV (production or a deployment env label) gets the generic

--- a/lib/helpers/responses.js
+++ b/lib/helpers/responses.js
@@ -194,27 +194,48 @@ const getHttpStatus = (status, err) => {
 };
 
 /**
- * @desc Resolve safe client description text for error payload
+ * @desc Resolve safe client description text for error payload. Takes the
+ * already-captured `details` value (see `rawDetails` at the `responses.error`
+ * call site) rather than reading `err.details` itself — `err.details` may be
+ * backed by a throwing getter, which would otherwise be invoked a SECOND
+ * time here, one frame below the try/catch that captures `rawDetails`
+ * (finding-4 follow-up: this used to re-read `err?.details` three times on its
+ * own, which let a throwing accessor escape for the most common call shape —
+ * no explicit `description`, no `error.description` — since that shape
+ * reaches every one of those reads). Capturing the value once does not by
+ * itself make it SAFE to read further, though: `details` can still be a
+ * hostile Proxy whose `get` trap throws on the property reads below
+ * (`item.message`, `details.message`) even though the initial capture of the
+ * Proxy reference itself never touched a trap — so those reads stay inside a
+ * try/catch too, same fail-closed, drop-and-fall-through-to-'' contract as
+ * `pickWhitelistedDetails` uses for the same shape of hostility.
  * @param {string} description - Explicit description override
  * @param {Object} err - Error object
+ * @param {*} details - Pre-captured `err.details` value (read once, under a
+ *   try/catch, by the caller) — used in place of every `err?.details` read
  * @return {string} error description
  */
-const getDescription = (description, err) => {
+const getDescription = (description, err, details) => {
   if (description) return description;
   if (err?.description) return err.description;
-  if (typeof err?.details === 'string') return err.details;
-  if (Array.isArray(err?.details)) {
-    const messages = err.details
-      .map((item) => {
-        if (!item) return null;
-        if (typeof item === 'string') return item;
-        if (typeof item.message === 'string') return item.message;
-        return null;
-      })
-      .filter(Boolean);
-    if (messages.length > 0) return messages.join(', ');
+  try {
+    if (typeof details === 'string') return details;
+    if (Array.isArray(details)) {
+      const messages = details
+        .map((item) => {
+          if (!item) return null;
+          if (typeof item === 'string') return item;
+          if (typeof item.message === 'string') return item.message;
+          return null;
+        })
+        .filter(Boolean);
+      if (messages.length > 0) return messages.join(', ');
+    }
+    if (details?.message) return details.message;
+  } catch (_err) {
+    // A hostile `details` shape (e.g. a Proxy whose `get` trap throws) must
+    // drop out to the empty-description default, not crash the response.
   }
-  if (err?.details?.message) return err.details.message;
   return '';
 };
 
@@ -256,7 +277,10 @@ const error = (res, httpStatus, message, description) => (error = {}) => {
   // above the fail-closed read inside `pickWhitelistedDetails` — see that
   // function's try/catch doc above). A throwing accessor here must drop the
   // details, not abort the whole response and hand the request's real
-  // status/message to the generic 500 handler.
+  // status/message to the generic 500 handler. Read exactly once and passed
+  // down to BOTH `pickWhitelistedDetails` and `getDescription` below — the
+  // latter used to re-read `err.details` on its own, which reintroduced the
+  // same crash for the default (no explicit description) call shape.
   let rawDetails;
   try {
     rawDetails = error.details;
@@ -270,7 +294,7 @@ const error = (res, httpStatus, message, description) => (error = {}) => {
     code: status,
     status,
     errorCode: getErrorCode(error),
-    description: getDescription(description, error),
+    description: getDescription(description, error, rawDetails),
     // Whitelisted details (e.g. billing's upgradeUrl/type) cross into every
     // environment, production included — see DETAILS_WHITELIST above. Only
     // added when at least one key matched, so most error responses are

--- a/lib/helpers/responses.js
+++ b/lib/helpers/responses.js
@@ -42,14 +42,22 @@ const DEFAULT_DETAILS_WHITELIST = ['upgradeUrl', 'type', 'retryAfter'];
  * `.includes()`, this one's entries become object property keys in
  * `pickWhitelistedDetails` below, where an unguarded `__proto__` could
  * reassign a prototype. A non-string, empty-string, or unsafe element is
- * dropped silently, never included and never crashes boot.
+ * dropped silently, never included and never crashes boot. Each string
+ * element is trimmed BEFORE the empty/unsafe checks — `config/index.js`'s
+ * `DEVKIT_NODE_*` env-var array parsing splits on `,` without trimming (that
+ * splitting is shared infrastructure, out of scope here), so an operator
+ * writing `"[upgradeUrl, planTier]"` would otherwise add a `' planTier'`
+ * (leading-space) entry that can never match the real (unpadded) property
+ * name — a dead whitelist entry, accepted silently, with no warning.
  * @param {*} value - the raw `config.errors.detailsWhitelist` value
  * @param {String} label - dotted config path for the warning message
  * @returns {Array} the sanitized, per-element-safe list; `[]` for a malformed whole value
  */
 const sanitizeConfigList = (value, label) => {
   if (Array.isArray(value)) {
-    return value.filter((key) => typeof key === 'string' && key.length > 0 && !UNSAFE_KEYS.has(key));
+    return value
+      .map((key) => (typeof key === 'string' ? key.trim() : key))
+      .filter((key) => typeof key === 'string' && key.length > 0 && !UNSAFE_KEYS.has(key));
   }
   if (value == null) return [];
   console.warn(`[responses] config.${label} ignored: expected an array, got ${typeof value}`);
@@ -140,15 +148,21 @@ const pickWhitelistedDetails = (details, whitelist = DETAILS_WHITELIST) => {
   if (!details || typeof details !== 'object' || Array.isArray(details)) return undefined;
   const picked = Object.create(null);
   for (const key of whitelist) {
-    if (!Object.prototype.hasOwnProperty.call(details, key)) continue;
     // A whitelisted key may be backed by a throwing getter (e.g. `details`
     // built from a raw caught exception whose accessor reads a closed
-    // resource). Reading it must never propagate out of the picker — that
-    // would abort the whole response instead of just dropping this one key
-    // — and must never stop the loop from picking the remaining whitelisted
-    // keys. Fail closed and stay silent-safe: same "drop this key" contract
-    // as every other unsafe shape handled by `isSafeDetailValue`.
+    // resource), OR `details` itself may be a hostile Proxy whose
+    // `getOwnPropertyDescriptor` trap throws — `hasOwnProperty` invokes that
+    // trap, so the OWNERSHIP CHECK must be inside the protected region too,
+    // not just the value read that follows it (round-2 follow-up: the
+    // try/catch below used to start AFTER this check, which left exactly
+    // that Proxy shape able to abort the whole response). Reading/checking
+    // it must never propagate out of the picker — that would abort the
+    // whole response instead of just dropping this one key — and must never
+    // stop the loop from picking the remaining whitelisted keys. Fail closed
+    // and stay silent-safe: same "drop this key" contract as every other
+    // unsafe shape handled by `isSafeDetailValue`.
     try {
+      if (!Object.prototype.hasOwnProperty.call(details, key)) continue;
       const value = details[key];
       if (isSafeDetailValue(value)) picked[key] = value;
     } catch (_err) {
@@ -238,7 +252,18 @@ const safeStringify = (value) => {
  */
 const error = (res, httpStatus, message, description) => (error = {}) => {
   const status = getHttpStatus(httpStatus, error);
-  const whitelistedDetails = pickWhitelistedDetails(error.details);
+  // `error.details` itself may be backed by a throwing getter (one frame
+  // above the fail-closed read inside `pickWhitelistedDetails` — see that
+  // function's try/catch doc above). A throwing accessor here must drop the
+  // details, not abort the whole response and hand the request's real
+  // status/message to the generic 500 handler.
+  let rawDetails;
+  try {
+    rawDetails = error.details;
+  } catch (_err) {
+    rawDetails = undefined;
+  }
+  const whitelistedDetails = pickWhitelistedDetails(rawDetails);
   const result = {
     type: 'error',
     message: message || error.message || 'Something went wrong.',

--- a/lib/helpers/responses.js
+++ b/lib/helpers/responses.js
@@ -1,5 +1,6 @@
 import config from '../../config/index.js';
 import configHelper from './config.js';
+import UNSAFE_KEYS from './unsafeKeys.js';
 
 /**
  * @desc Function res success
@@ -25,49 +26,123 @@ const DEFAULT_DETAILS_WHITELIST = ['upgradeUrl', 'type', 'retryAfter'];
 
 /**
  * @desc Sanitize a config-provided whitelist extension so a typo or wrong
- * type can never crash boot or silently degrade into something unsafe.
- * Mirrors `redactUrl.js#sanitizeConfigList` — same union-only contract.
+ * type can never crash boot or silently degrade into something unsafe. Two
+ * layers of validation: (1) whole-value shape — a non-array value (typo,
+ * wrong type) degrades to `[]`, a no-op for the union below, same contract as
+ * `redactUrl.js#sanitizeConfigList`; (2) per-element — each surviving element
+ * must be a non-empty string AND may not be one of `UNSAFE_KEYS`
+ * (`__proto__`/`constructor`/`prototype`, from `./unsafeKeys.js` — the SAME
+ * Set `config/index.js#deepMerge` guards its own merge with, so the two
+ * guards cannot drift apart. Extracted to its own tiny module rather than
+ * imported from `config/index.js` directly: that module is mocked down to
+ * `{ default: {...} }`, no named exports, across ~100 test files, so a
+ * required named import from it would break every one of those mocks —
+ * demonstrated, not theoretical). The per-element layer is additional
+ * versus `redactUrl.js`'s copy: that list is only ever used with
+ * `.includes()`, this one's entries become object property keys in
+ * `pickWhitelistedDetails` below, where an unguarded `__proto__` could
+ * reassign a prototype. A non-string, empty-string, or unsafe element is
+ * dropped silently, never included and never crashes boot.
  * @param {*} value - the raw `config.errors.detailsWhitelist` value
  * @param {String} label - dotted config path for the warning message
- * @return {Array} `value` unchanged when it is already an array, otherwise `[]`
+ * @return {Array} the sanitized, per-element-safe list; `[]` for a malformed whole value
  */
 const sanitizeConfigList = (value, label) => {
-  if (Array.isArray(value)) return value;
+  if (Array.isArray(value)) {
+    return value.filter((key) => typeof key === 'string' && key.length > 0 && !UNSAFE_KEYS.has(key));
+  }
   if (value == null) return [];
   console.warn(`[responses] config.${label} ignored: expected an array, got ${typeof value}`);
   return [];
 };
 
 /**
- * Union of `DEFAULT_DETAILS_WHITELIST` and `config.errors.detailsWhitelist`: a
- * downstream project ADDS its own production-safe detail keys from its own
- * config, without patching this stack file. Deduplicated via `Set`. Missing
- * config, a missing key, an explicit empty array, or a malformed (non-array)
- * value all resolve to exactly the built-in defaults — config can only ever
- * grow this set with keys the downstream project itself opts in, never turn
- * it into a denylist and never remove a built-in entry.
+ * @desc Pure builder for the effective whitelist: sanitize `configValue` (see
+ * `sanitizeConfigList`) and union it with `DEFAULT_DETAILS_WHITELIST`.
+ * Extracted as a pure function (config value in, `Set` out) rather than only
+ * existing as the module-load-time `DETAILS_WHITELIST` singleton below, so
+ * config-widening — including the `UNSAFE_KEYS` rejection and per-element
+ * filtering — is directly unit-testable without `jest.resetModules()`
+ * gymnastics.
+ * @param {*} configValue - the raw `config.errors.detailsWhitelist` value
+ * @return {Set<String>} the built-in defaults unioned with the sanitized config extension
  */
-const DETAILS_WHITELIST = new Set([
-  ...DEFAULT_DETAILS_WHITELIST,
-  ...sanitizeConfigList(config?.errors?.detailsWhitelist, 'errors.detailsWhitelist'),
-]);
+const buildWhitelist = (configValue) => new Set([...DEFAULT_DETAILS_WHITELIST, ...sanitizeConfigList(configValue, 'errors.detailsWhitelist')]);
+
+/**
+ * Union of `DEFAULT_DETAILS_WHITELIST` and `config.errors.detailsWhitelist`
+ * (via `buildWhitelist` above): a downstream project ADDS its own
+ * production-safe detail keys from its own config, without patching this
+ * stack file. Deduplicated via `Set`. Missing config, a missing key, an
+ * explicit empty array, or a malformed (non-array) value all resolve to
+ * exactly the built-in defaults. Per element, `sanitizeConfigList` also drops
+ * anything that is not a non-empty string and anything in `UNSAFE_KEYS`
+ * (`__proto__`/`constructor`/`prototype`) — config can only ever grow this
+ * set with safe, downstream-chosen keys, never turn it into a denylist,
+ * never remove a built-in entry, and never smuggle in a prototype-polluting
+ * key.
+ */
+const DETAILS_WHITELIST = buildWhitelist(config?.errors?.detailsWhitelist);
+
+/**
+ * Whitelisted-detail values must be safe, boring scalars — a whitelisted KEY
+ * only gates which properties are looked at; without a value check too, a
+ * caller that hands the picker a raw exception (`details: err` / `details:
+ * err.details || err` — several call sites across the stack do exactly this)
+ * could leak an entire nested object simply by that exception owning a
+ * property that happens to be named `type`, `upgradeUrl` or `retryAfter`.
+ * Safe = `null`, a `boolean`, a finite `number`, or a `string` no longer than
+ * `MAX_DETAIL_VALUE_LENGTH`. Everything else (object, array, function,
+ * `undefined`, `NaN`/`Infinity`, an over-length string) is dropped, never
+ * coerced or stringified — fail closed.
+ * @readonly
+ */
+const MAX_DETAIL_VALUE_LENGTH = 200; // generous for a real upgradeUrl path or a short enum-style
+// type/retryAfter value, but bounded so a raw exception's arbitrarily long
+// string property (e.g. a stack-trace-shaped `.type`) can't inject an
+// oversized blob into the production response body.
+
+/**
+ * @desc Decide whether a single whitelisted-key value is safe to serialize
+ * into the production error envelope. See `MAX_DETAIL_VALUE_LENGTH` doc above
+ * for the exact safe shape and the reasoning behind it.
+ * @param {*} value - the value found at a whitelisted key
+ * @return {boolean} true when `value` is a safe scalar
+ */
+const isSafeDetailValue = (value) => {
+  if (value === null || typeof value === 'boolean') return true;
+  if (typeof value === 'number') return Number.isFinite(value);
+  if (typeof value === 'string') return value.length <= MAX_DETAIL_VALUE_LENGTH;
+  return false;
+};
 
 /**
  * @desc Pick the production-safe subset of `AppError.details` by EXACT key
- * match against `DETAILS_WHITELIST`. Applies in every environment — there is
- * nothing dev-only about it, it is a strict subset of what dev-grade envs
- * already get via the full serialized-error blob below. Anything that is not
- * a plain object (a bare string, the `[{ message }]` array AppError defaults
- * to, `undefined`) has no own keys to match and yields no result, so the
- * common case (no whitelisted key present) adds nothing to the envelope.
+ * match against `whitelist`, keeping ONLY values that pass
+ * `isSafeDetailValue` — a matched key whose value is an object, array,
+ * function, `undefined` or non-finite number is dropped, not passed through
+ * (see `isSafeDetailValue` doc for why the key match alone is not enough).
+ * Applies in every environment — there is nothing dev-only about it, it is a
+ * strict subset of what dev-grade envs already get via the full
+ * serialized-error blob below. Anything that is not a plain object (a bare
+ * string, the `[{ message }]` array AppError defaults to, `undefined`) has no
+ * own keys to match and yields no result, so the common case (no whitelisted
+ * key present) adds nothing to the envelope. Builds the result with
+ * `Object.create(null)` — belt and braces alongside the `UNSAFE_KEYS` config
+ * guard above — so even a details object carrying a real own `__proto__`
+ * property can only ever become an own data property on the picked object,
+ * never reassign its prototype ahead of `JSON.stringify`.
  * @param {*} details - `AppError.details`, in whatever shape the throw site built it
- * @return {Object|undefined} whitelisted key/value pairs, or `undefined` when none matched
+ * @param {Set<String>} [whitelist] - keys to match; defaults to the module's `DETAILS_WHITELIST`
+ * @return {Object|undefined} whitelisted key/value pairs (a null-prototype object), or `undefined` when none matched
  */
-const pickWhitelistedDetails = (details) => {
+const pickWhitelistedDetails = (details, whitelist = DETAILS_WHITELIST) => {
   if (!details || typeof details !== 'object' || Array.isArray(details)) return undefined;
-  const picked = {};
-  for (const key of DETAILS_WHITELIST) {
-    if (Object.prototype.hasOwnProperty.call(details, key)) picked[key] = details[key];
+  const picked = Object.create(null);
+  for (const key of whitelist) {
+    if (!Object.prototype.hasOwnProperty.call(details, key)) continue;
+    const value = details[key];
+    if (isSafeDetailValue(value)) picked[key] = value;
   }
   return Object.keys(picked).length > 0 ? picked : undefined;
 };
@@ -178,3 +253,8 @@ export default {
   success,
   error,
 };
+
+// Pure helpers exported for direct unit testing — see `pickWhitelistedDetails`
+// and `buildWhitelist` doc comments above for why (belt-and-braces
+// null-prototype defense, and config-widening without `jest.resetModules()`).
+export { buildWhitelist, pickWhitelistedDetails, isSafeDetailValue };

--- a/lib/helpers/tests/responses.detailsWhitelist.unit.tests.js
+++ b/lib/helpers/tests/responses.detailsWhitelist.unit.tests.js
@@ -219,6 +219,74 @@ describe('responses.error — whitelisted details value validation (finding 1):'
 });
 
 /**
+ * Unit tests — a throwing getter must never crash the picker (post-#3958
+ * follow-up review, finding 1). `AppError.details` is populated with a raw
+ * caught exception at several call sites; a value backed by a getter that
+ * throws must be treated the same as any other unsafe shape — dropped,
+ * never propagated — and must not stop the loop from picking the remaining
+ * whitelisted keys.
+ */
+describe('pickWhitelistedDetails — a throwing getter is dropped, not propagated (follow-up finding 1):', () => {
+  let originalNodeEnv;
+
+  beforeEach(() => {
+    originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  test('a throwing getter on the FIRST whitelisted key does not prevent LATER whitelisted keys from being picked, and the response still carries the intended status/message', () => {
+    const res = buildRes();
+    const details = { type: 'METER_EXHAUSTED', retryAfter: 30 };
+    Object.defineProperty(details, 'upgradeUrl', {
+      enumerable: true,
+      get() {
+        throw new Error('boom from a getter');
+      },
+    });
+    const err = new AppError('Meter exhausted', { status: 402, details });
+    expect(() => responses.error(res, 402)(err)).not.toThrow();
+    expect(res._status).toBe(402);
+    expect(res._body.message).toBe('Meter exhausted');
+    expect(res._body.details).toEqual({ type: 'METER_EXHAUSTED', retryAfter: 30 });
+    expect(res._body.details.upgradeUrl).toBeUndefined();
+  });
+
+  test('a throwing getter on a MIDDLE whitelisted key does not partially populate — every other whitelisted key is still present', () => {
+    const res = buildRes();
+    const details = { upgradeUrl: '/billing/plans', retryAfter: 30 };
+    Object.defineProperty(details, 'type', {
+      enumerable: true,
+      get() {
+        throw new Error('boom from a getter');
+      },
+    });
+    const err = new AppError('Meter exhausted', { status: 402, details });
+    expect(() => responses.error(res, 402)(err)).not.toThrow();
+    expect(res._status).toBe(402);
+    expect(res._body.details).toEqual({ upgradeUrl: '/billing/plans', retryAfter: 30 });
+  });
+
+  test('pickWhitelistedDetails called directly with a throwing getter never throws and drops only the throwing key', () => {
+    const details = { retryAfter: 30 };
+    Object.defineProperty(details, 'type', {
+      enumerable: true,
+      get() {
+        throw new Error('boom from a getter');
+      },
+    });
+    let picked;
+    expect(() => {
+      picked = pickWhitelistedDetails(details);
+    }).not.toThrow();
+    expect(picked).toEqual({ retryAfter: 30 });
+  });
+});
+
+/**
  * Unit tests — `buildWhitelist` (issue #3958 review findings 2 & 3): the
  * config-provided extension to the built-in whitelist must reject
  * prototype-polluting key names and filter non-string/empty elements, per

--- a/lib/helpers/tests/responses.detailsWhitelist.unit.tests.js
+++ b/lib/helpers/tests/responses.detailsWhitelist.unit.tests.js
@@ -350,9 +350,9 @@ describe('pickWhitelistedDetails — a throwing getter is dropped, not propagate
  * property nested inside `details`) crashes that read before it ever reaches
  * the picker's own try/catch, losing the request's real status/message to
  * whatever generic handler catches the escaped exception. An explicit
- * `description` argument is passed so the (separately unguarded,
- * out-of-scope) `getDescription` read of `err?.details` is never reached —
- * isolating this test to the exact line 255 read this fix protects.
+ * `description` argument is passed here so this test isolates the exact
+ * `rawDetails = error.details` read this fix protects — the separate
+ * `getDescription` re-read is now ALSO guarded (finding-4 follow-up below).
  */
 describe('responses.error — a throwing `details` accessor on the error object itself does not crash the response (finding 4):', () => {
   let originalNodeEnv;
@@ -379,6 +379,168 @@ describe('responses.error — a throwing `details` accessor on the error object 
     expect(res._status).toBe(402);
     expect(res._body.message).toBe('Meter exhausted');
     expect(res._body.details).toBeUndefined();
+  });
+});
+
+/**
+ * Unit tests — finding-4 follow-up: `getDescription(description, err)`
+ * used to re-read `err?.details` a SECOND time, unguarded, one frame below
+ * the try/catch that captures `rawDetails` in `responses.error` (finding 4
+ * above). For the DEFAULT call shape — `responses.error(res, status)(err)`,
+ * no explicit `description`, no `error.description` — `getDescription`
+ * reaches `typeof err?.details === 'string'` and a throwing `details`
+ * accessor propagated out of `responses.error` anyway, even though finding 4
+ * was supposedly fixed. Same for a `details` Proxy whose `get` trap throws:
+ * capturing the Proxy REFERENCE once (`rawDetails = error.details`) never
+ * touches the trap, so `getDescription`'s later `details.message` read was
+ * still the first UNGUARDED property access on that hostile Proxy —
+ * `pickWhitelistedDetails` runs first and already reads `details[key]`
+ * inside its own per-key try/catch, so it never propagates. The existing
+ * finding-4 test above never caught this because it passes an explicit
+ * `description`, which returns before `getDescription` ever reads `details`.
+ */
+describe('responses.error — a throwing `details` getter/Proxy does not crash the DEFAULT call shape (finding-4 follow-up — getDescription second read):', () => {
+  let originalNodeEnv;
+
+  beforeEach(() => {
+    originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  test('a throwing `details` getter does not crash responses.error(res, status)(err) — no explicit description, no error.description', () => {
+    const res = buildRes();
+    const err = new AppError('Meter exhausted', { status: 402 });
+    Object.defineProperty(err, 'details', {
+      configurable: true,
+      get() {
+        throw new Error('boom from a getter');
+      },
+    });
+    expect(() => responses.error(res, 402)(err)).not.toThrow();
+    expect(res._status).toBe(402);
+    expect(res._body.message).toBe('Meter exhausted');
+    expect(res._body.details).toBeUndefined();
+    expect(res._body.description).toBe('');
+  });
+
+  test('a `details` Proxy whose get trap throws does not crash responses.error(res, status)(err) — no explicit description, no error.description', () => {
+    const res = buildRes();
+    const hostileDetails = new Proxy(
+      { upgradeUrl: '/billing/plans' },
+      {
+        get() {
+          throw new Error('proxy get trap boom');
+        },
+      },
+    );
+    const err = new AppError('Meter exhausted', { status: 402, details: hostileDetails });
+    expect(() => responses.error(res, 402)(err)).not.toThrow();
+    expect(res._status).toBe(402);
+    expect(res._body.message).toBe('Meter exhausted');
+    // `hasOwnProperty` (used by `pickWhitelistedDetails`) forwards to the
+    // Proxy's `getOwnPropertyDescriptor` trap, not `get` — this Proxy only
+    // overrides `get`, so ownership checks pass and every whitelisted key's
+    // VALUE read (`details[key]`) is what throws and gets dropped, leaving
+    // no whitelisted key picked at all.
+    expect(res._body.details).toBeUndefined();
+    // getDescription's own `details.message` read hits the same `get` trap
+    // and is caught the same way, falling through to the empty default.
+    expect(res._body.description).toBe('');
+  });
+});
+
+/**
+ * Unit tests — `getDescription`'s pre-existing description-resolution
+ * semantics (string `details`, array-of-`{message}` `details`, absent
+ * `details`, explicit `description`, `error.description`) are OUT OF SCOPE
+ * for the finding-4 follow-up above and must be byte-identical to before it: only
+ * the SOURCE of the `details` value getDescription reads changed (a
+ * pre-captured value instead of a live re-read of `err.details`), never the
+ * resolution logic itself. Expected strings captured from the pre-fix
+ * behavior directly (see PR #4056 discussion) — this is a behavior-lock, not
+ * a spec derived from reasoning about the new code.
+ */
+describe('responses.error — getDescription behavior preservation (finding-4 follow-up must not change these):', () => {
+  let originalNodeEnv;
+
+  beforeEach(() => {
+    originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  test('a string `details`, no explicit description, no error.description — description is the string itself', () => {
+    const res = buildRes();
+    const err = new AppError('Meter exhausted', { status: 402, details: 'a string detail' });
+    responses.error(res, 402)(err);
+    expect(res._body.description).toBe('a string detail');
+  });
+
+  test('an array-of-{message} `details` — description is the joined messages', () => {
+    const res = buildRes();
+    const err = new AppError('Meter exhausted', {
+      status: 402,
+      details: [{ message: 'first' }, { message: 'second' }],
+    });
+    responses.error(res, 402)(err);
+    expect(res._body.description).toBe('first, second');
+  });
+
+  test('a mixed array `details` (message objects, plain strings, falsy, non-message objects) — non-matching entries are dropped', () => {
+    const res = buildRes();
+    const err = new AppError('Meter exhausted', {
+      status: 402,
+      details: [{ message: 'first' }, 'plain', null, { other: 'x' }],
+    });
+    responses.error(res, 402)(err);
+    expect(res._body.description).toBe('first, plain');
+  });
+
+  test('absent `details`, no explicit description, no error.description — description is the empty string', () => {
+    const res = buildRes();
+    // AppError's constructor always defaults `details` to `[{ message }]`
+    // when none is passed — `delete` here gets a TRULY absent `details`,
+    // matching a raw (non-AppError) error object handed to responses.error.
+    const err = new AppError('Meter exhausted', { status: 402 });
+    delete err.details;
+    responses.error(res, 402)(err);
+    expect(res._body.description).toBe('');
+  });
+
+  test('an explicit `description` argument wins over `details`, even when `details` is set', () => {
+    const res = buildRes();
+    const err = new AppError('Meter exhausted', { status: 402, details: 'should not be used' });
+    responses.error(res, 402, 'Meter exhausted', 'explicit description')(err);
+    expect(res._body.description).toBe('explicit description');
+  });
+
+  test('`error.description` wins over `details` when no explicit description argument is given', () => {
+    const res = buildRes();
+    const err = new AppError('Meter exhausted', { status: 402, details: 'should not be used' });
+    err.description = 'err-level description';
+    responses.error(res, 402)(err);
+    expect(res._body.description).toBe('err-level description');
+  });
+
+  test('an object `details` with a `.message` (not a string, not an array) — description is that message', () => {
+    const res = buildRes();
+    const err = new AppError('Meter exhausted', { status: 402, details: { message: 'object details message' } });
+    responses.error(res, 402)(err);
+    expect(res._body.description).toBe('object details message');
+  });
+
+  test('an object `details` with no `.message` and no whitelisted key — description is the empty string', () => {
+    const res = buildRes();
+    const err = new AppError('Meter exhausted', { status: 402, details: { foo: 'bar' } });
+    responses.error(res, 402)(err);
+    expect(res._body.description).toBe('');
   });
 });
 

--- a/lib/helpers/tests/responses.detailsWhitelist.unit.tests.js
+++ b/lib/helpers/tests/responses.detailsWhitelist.unit.tests.js
@@ -2,7 +2,7 @@
  * Module dependencies.
  */
 import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
-import responses from '../responses.js';
+import responses, { buildWhitelist, pickWhitelistedDetails } from '../responses.js';
 import AppError from '../AppError.js';
 
 /**
@@ -115,5 +115,178 @@ describe('responses.error — whitelisted details gating:', () => {
     responses.error(res, 500)(err);
     expect(res._body.error).toContain('internalStack');
     expect(res._body.details).toBeUndefined();
+  });
+});
+
+/**
+ * Unit tests — a whitelisted KEY match is not enough: the VALUE at that key
+ * must also be a safe scalar (issue #3958 review finding 1). Several
+ * pre-existing call sites across the stack hand this a raw caught exception
+ * (`details: err` / `details: err.details || err`), so any future error
+ * shape exposing an own `type`/`upgradeUrl`/`retryAfter` property must not
+ * leak its full value just because the key matched.
+ */
+describe('responses.error — whitelisted details value validation (finding 1):', () => {
+  let originalNodeEnv;
+
+  beforeEach(() => {
+    originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  test('a nested object under a whitelisted key is dropped, not serialized into the production response', () => {
+    const res = buildRes();
+    const err = new AppError('boom', {
+      status: 500,
+      details: { type: { dbHost: 'internal-db.local', secret: 'internal-only' } },
+    });
+    responses.error(res, 500)(err);
+    expect(res._body.details).toBeUndefined();
+  });
+
+  test('a nested object under upgradeUrl is dropped too', () => {
+    const res = buildRes();
+    const err = new AppError('boom', { status: 500, details: { upgradeUrl: { dbHost: 'internal-db.local' } } });
+    responses.error(res, 500)(err);
+    expect(res._body.details).toBeUndefined();
+  });
+
+  test('an unsafe (object) value at one whitelisted key is dropped while a safe sibling key is kept', () => {
+    const res = buildRes();
+    const err = new AppError('boom', {
+      status: 402,
+      details: { type: 'METER_EXHAUSTED', upgradeUrl: { nested: true } },
+    });
+    responses.error(res, 402)(err);
+    expect(res._body.details).toEqual({ type: 'METER_EXHAUSTED' });
+  });
+
+  test('an array value at a whitelisted key is dropped', () => {
+    const res = buildRes();
+    const err = new AppError('boom', { status: 500, details: { type: ['a', 'b'] } });
+    responses.error(res, 500)(err);
+    expect(res._body.details).toBeUndefined();
+  });
+
+  test('a function value at a whitelisted key is dropped', () => {
+    const res = buildRes();
+    const err = new AppError('boom', { status: 500, details: { type() {} } });
+    responses.error(res, 500)(err);
+    expect(res._body.details).toBeUndefined();
+  });
+
+  test('an explicit undefined value at a whitelisted key is dropped', () => {
+    const res = buildRes();
+    const err = new AppError('boom', { status: 500, details: { type: undefined } });
+    responses.error(res, 500)(err);
+    expect(res._body.details).toBeUndefined();
+  });
+
+  test('a non-finite number (NaN/Infinity) value at a whitelisted key is dropped', () => {
+    const res = buildRes();
+    const err = new AppError('boom', { status: 500, details: { retryAfter: Infinity } });
+    responses.error(res, 500)(err);
+    expect(res._body.details).toBeUndefined();
+  });
+
+  test('a whitelisted string value longer than the safe length cap is dropped', () => {
+    const res = buildRes();
+    const err = new AppError('boom', { status: 500, details: { type: 'x'.repeat(201) } });
+    responses.error(res, 500)(err);
+    expect(res._body.details).toBeUndefined();
+  });
+
+  test('safe scalars (finite number, boolean, string within the cap, null) are all kept', () => {
+    const res = buildRes();
+    const err = new AppError('boom', {
+      status: 402,
+      details: { retryAfter: 30, upgradeUrl: '/billing/plans', type: null },
+    });
+    responses.error(res, 402)(err);
+    expect(res._body.details).toEqual({ retryAfter: 30, upgradeUrl: '/billing/plans', type: null });
+  });
+
+  test('a case-variant key (TYPE, UpgradeUrl) is not matched — exact key name only', () => {
+    const res = buildRes();
+    const err = new AppError('boom', { status: 500, details: { TYPE: 'x', UpgradeUrl: '/y' } });
+    responses.error(res, 500)(err);
+    expect(res._body.details).toBeUndefined();
+  });
+});
+
+/**
+ * Unit tests — `buildWhitelist` (issue #3958 review findings 2 & 3): the
+ * config-provided extension to the built-in whitelist must reject
+ * prototype-polluting key names and filter non-string/empty elements, per
+ * element, not just reject a malformed whole value.
+ */
+describe('buildWhitelist — config-provided whitelist extension sanitation (findings 2 & 3):', () => {
+  const BUILT_INS = ['upgradeUrl', 'type', 'retryAfter'];
+
+  test('rejects __proto__ from the config extension', () => {
+    const whitelist = buildWhitelist(['__proto__']);
+    expect(whitelist.has('__proto__')).toBe(false);
+    expect([...whitelist].sort()).toEqual([...BUILT_INS].sort());
+  });
+
+  test('rejects constructor and prototype from the config extension', () => {
+    const whitelist = buildWhitelist(['constructor', 'prototype']);
+    expect(whitelist.has('constructor')).toBe(false);
+    expect(whitelist.has('prototype')).toBe(false);
+  });
+
+  test('keeps a legitimate downstream key alongside a rejected unsafe one', () => {
+    const whitelist = buildWhitelist(['__proto__', 'aDownstreamSafeKey']);
+    expect(whitelist.has('aDownstreamSafeKey')).toBe(true);
+    expect(whitelist.has('__proto__')).toBe(false);
+  });
+
+  test('filters non-string and empty-string elements, keeping valid string elements', () => {
+    const whitelist = buildWhitelist(['aKey', 123, {}, null, '', 'anotherKey']);
+    const extras = [...whitelist].filter((key) => !BUILT_INS.includes(key));
+    expect(extras.sort()).toEqual(['aKey', 'anotherKey']);
+  });
+
+  test('a malformed (non-array) config value degrades to exactly the built-in defaults', () => {
+    expect([...buildWhitelist('not-an-array')].sort()).toEqual([...BUILT_INS].sort());
+    expect([...buildWhitelist({})].sort()).toEqual([...BUILT_INS].sort());
+    expect([...buildWhitelist(null)].sort()).toEqual([...BUILT_INS].sort());
+    expect([...buildWhitelist(undefined)].sort()).toEqual([...BUILT_INS].sort());
+  });
+});
+
+/**
+ * Unit tests — belt-and-braces null-prototype defense in
+ * `pickWhitelistedDetails` (issue #3958 review finding 2), isolated from the
+ * OTHER two defenses (the config-side `UNSAFE_KEYS` guard, and finding 1's
+ * scalar-value guard) so this specific mechanism is not decoration: an
+ * object-shaped `__proto__` value is already intercepted by finding 1's
+ * value guard before it would ever reach this code path, so that shape
+ * cannot exercise this test in isolation — a scalar value is used instead,
+ * matching what `isSafeDetailValue` accepts, to reach the assignment itself.
+ */
+describe('pickWhitelistedDetails — null-prototype belt-and-braces (finding 2):', () => {
+  test('the returned object always has a null prototype, for an ordinary safe pick', () => {
+    const picked = pickWhitelistedDetails({ upgradeUrl: '/billing/plans' });
+    expect(Object.getPrototypeOf(picked)).toBeNull();
+  });
+
+  test('a details object with a real own "__proto__" property (safe scalar value), matched by the whitelist, is stored as a data property without reassigning the picked object prototype', () => {
+    // Object.defineProperty (like JSON.parse would for `{"__proto__": "x"}`)
+    // creates a genuine OWN property named "__proto__" — unlike the
+    // `{ __proto__: x }` object-literal syntax, which the spec special-cases
+    // to set the prototype directly instead of creating an own property.
+    const maliciousDetails = Object.defineProperty({}, '__proto__', {
+      value: 'not-an-object-marker',
+      enumerable: true,
+    });
+    const picked = pickWhitelistedDetails(maliciousDetails, new Set(['__proto__']));
+    expect(Object.getPrototypeOf(picked)).toBeNull();
+    expect(Object.prototype.hasOwnProperty.call(picked, '__proto__')).toBe(true);
+    expect(picked.__proto__).toBe('not-an-object-marker');
   });
 });

--- a/lib/helpers/tests/responses.detailsWhitelist.unit.tests.js
+++ b/lib/helpers/tests/responses.detailsWhitelist.unit.tests.js
@@ -1,0 +1,119 @@
+/**
+ * Module dependencies.
+ */
+import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import responses from '../responses.js';
+import AppError from '../AppError.js';
+
+/**
+ * Build a minimal Express response double that captures status + json body.
+ * @returns {{status: Function, json: Function, _status: number, _body: object}}
+ */
+const buildRes = () => {
+  const res = {
+    _status: undefined,
+    _body: undefined,
+    status(code) { this._status = code; return this; },
+    json(body) { this._body = body; return this; },
+  };
+  return res;
+};
+
+/**
+ * Unit tests — production-safe whitelisted `AppError.details` keys must cross
+ * into the error envelope in EVERY environment, while everything else stays
+ * dev-only exactly as before (issue #3958). Whitelist is opt-in by exact key
+ * name (`upgradeUrl`, `type`, `retryAfter`) — a key not on that list is
+ * dropped, never passed through by shape or naming convention.
+ */
+describe('responses.error — whitelisted details gating:', () => {
+  let originalNodeEnv;
+
+  beforeEach(() => {
+    originalNodeEnv = process.env.NODE_ENV;
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  test('a whitelisted key (upgradeUrl) passes through in production mode', () => {
+    process.env.NODE_ENV = 'production';
+    const res = buildRes();
+    const err = new AppError('Meter exhausted', {
+      status: 402,
+      details: { type: 'METER_EXHAUSTED', upgradeUrl: '/billing/plans' },
+    });
+    responses.error(res, 402)(err);
+    expect(res._body.details).toEqual({ type: 'METER_EXHAUSTED', upgradeUrl: '/billing/plans' });
+    // Still no raw-error leak alongside it.
+    expect(res._body.error).toBeUndefined();
+  });
+
+  test('a whitelisted key passes through under any non-dev NODE_ENV label, not just the literal "production"', () => {
+    process.env.NODE_ENV = 'someproject';
+    const res = buildRes();
+    const err = new AppError('Meter exhausted', { status: 402, details: { upgradeUrl: '/billing/plans' } });
+    responses.error(res, 402)(err);
+    expect(res._body.details).toEqual({ upgradeUrl: '/billing/plans' });
+  });
+
+  test('a NON-whitelisted key is stripped in production mode', () => {
+    process.env.NODE_ENV = 'production';
+    const res = buildRes();
+    const err = new AppError('Meter exhausted', {
+      status: 402,
+      details: { upgradeUrl: '/billing/plans', internalAccountId: 'acct_super_secret' },
+    });
+    responses.error(res, 402)(err);
+    expect(res._body.details).toEqual({ upgradeUrl: '/billing/plans' });
+    expect(res._body.details.internalAccountId).toBeUndefined();
+  });
+
+  test('details with ONLY non-whitelisted keys adds no `details` field at all, in production', () => {
+    process.env.NODE_ENV = 'production';
+    const res = buildRes();
+    const err = new AppError('Repository failure', {
+      status: 500,
+      details: { internalStack: 'at Object.<anonymous> (/app/lib.js:12:5)' },
+    });
+    responses.error(res, 500)(err);
+    expect(res._body.details).toBeUndefined();
+  });
+
+  test('a validation-style array `details` (the AppError default shape) adds no `details` field, in production', () => {
+    process.env.NODE_ENV = 'production';
+    const res = buildRes();
+    // No `details` passed → AppError defaults to `[{ message }]`.
+    const err = new AppError('Something went wrong.');
+    responses.error(res, 500)(err);
+    expect(res._body.details).toBeUndefined();
+  });
+
+  test('dev/test behavior is unchanged: full raw details still serialize via the existing dev-only blob', () => {
+    process.env.NODE_ENV = 'development';
+    const res = buildRes();
+    const err = new AppError('Meter exhausted', {
+      status: 402,
+      details: { type: 'METER_EXHAUSTED', upgradeUrl: '/billing/plans', meterUsed: 5000, meterQuota: 5000 },
+    });
+    responses.error(res, 402)(err);
+    // Full details (including non-whitelisted meterUsed/meterQuota) still reach
+    // the client via the pre-existing dev-only serialized-error blob.
+    expect(typeof res._body.error).toBe('string');
+    expect(res._body.error).toContain('meterUsed');
+    expect(res._body.error).toContain('meterQuota');
+    // AND the whitelisted subset is present at the top level too (uniform shape
+    // across environments — a client never has to special-case dev).
+    expect(res._body.details).toEqual({ type: 'METER_EXHAUSTED', upgradeUrl: '/billing/plans' });
+  });
+
+  test('dev/test behavior is unchanged: a non-whitelisted-only details object still shows up in the dev blob', () => {
+    process.env.NODE_ENV = 'test';
+    const res = buildRes();
+    const err = new AppError('Repository failure', { status: 500, details: { internalStack: 'trace here' } });
+    responses.error(res, 500)(err);
+    expect(res._body.error).toContain('internalStack');
+    expect(res._body.details).toBeUndefined();
+  });
+});

--- a/lib/helpers/tests/responses.detailsWhitelist.unit.tests.js
+++ b/lib/helpers/tests/responses.detailsWhitelist.unit.tests.js
@@ -1,7 +1,7 @@
 /**
  * Module dependencies.
  */
-import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import { jest, describe, test, expect, beforeEach, afterEach } from '@jest/globals';
 import responses, { buildWhitelist, pickWhitelistedDetails } from '../responses.js';
 import AppError from '../AppError.js';
 
@@ -200,14 +200,32 @@ describe('responses.error — whitelisted details value validation (finding 1):'
     expect(res._body.details).toBeUndefined();
   });
 
-  test('safe scalars (finite number, boolean, string within the cap, null) are all kept', () => {
+  // Boundary asserted on BOTH sides (finding 5, 2026-09 review round): only
+  // the over-cap (201) side was previously tested, so a `<=` -> `<` mutation
+  // of the length check survived the whole suite — it would silently drop a
+  // real 200-char `upgradeUrl` in production. Asserting exactly-200-is-kept
+  // alongside the existing 201-is-dropped test pins both sides of the cap.
+  test('a whitelisted string value of EXACTLY the safe length cap (200 chars) is kept', () => {
     const res = buildRes();
-    const err = new AppError('boom', {
-      status: 402,
-      details: { retryAfter: 30, upgradeUrl: '/billing/plans', type: null },
-    });
+    const err = new AppError('boom', { status: 402, details: { type: 'x'.repeat(200) } });
     responses.error(res, 402)(err);
-    expect(res._body.details).toEqual({ retryAfter: 30, upgradeUrl: '/billing/plans', type: null });
+    expect(res._body.details).toEqual({ type: 'x'.repeat(200) });
+  });
+
+  // Actual boolean value used (finding 6, 2026-09 review round): the
+  // fixture previously named "boolean" in this test's title never included
+  // one (`type: null` covered null, not boolean), so deleting the
+  // `typeof value === 'boolean'` branch of `isSafeDetailValue` survived the
+  // whole suite. `pickWhitelistedDetails` is called directly with an
+  // explicit 4-key whitelist so all four safe-scalar kinds the title claims
+  // (finite number, boolean, string within the cap, null) can be exercised
+  // in one fixture despite the module's default whitelist having only 3 keys.
+  test('safe scalars (finite number, boolean, string within the cap, null) are all kept', () => {
+    const picked = pickWhitelistedDetails(
+      { retryAfter: 30, isRetryable: true, upgradeUrl: '/billing/plans', type: null },
+      new Set(['retryAfter', 'isRetryable', 'upgradeUrl', 'type']),
+    );
+    expect(picked).toEqual({ retryAfter: 30, isRetryable: true, upgradeUrl: '/billing/plans', type: null });
   });
 
   test('a case-variant key (TYPE, UpgradeUrl) is not matched — exact key name only', () => {
@@ -284,6 +302,84 @@ describe('pickWhitelistedDetails — a throwing getter is dropped, not propagate
     }).not.toThrow();
     expect(picked).toEqual({ retryAfter: 30 });
   });
+
+  // Finding 3 (2026-09 review round): the OWNERSHIP CHECK itself, not just
+  // the value read after it, must be inside the protected region. A `details`
+  // that is a hostile Proxy whose `getOwnPropertyDescriptor` trap throws
+  // makes `Object.prototype.hasOwnProperty.call(details, key)` throw (that
+  // call invokes the trap) — a shape the round-2 fix above did not cover,
+  // since its try/catch started AFTER the ownership check.
+  test('a `details` Proxy whose getOwnPropertyDescriptor trap throws does not crash the response — status/message still sent', () => {
+    const res = buildRes();
+    const hostileDetails = new Proxy(
+      {},
+      {
+        getOwnPropertyDescriptor() {
+          throw new Error('trap boom');
+        },
+      },
+    );
+    const err = new AppError('Meter exhausted', { status: 402, details: hostileDetails });
+    expect(() => responses.error(res, 402, 'Meter exhausted')(err)).not.toThrow();
+    expect(res._status).toBe(402);
+    expect(res._body.message).toBe('Meter exhausted');
+    expect(res._body.details).toBeUndefined();
+  });
+
+  test('pickWhitelistedDetails called directly with a getOwnPropertyDescriptor-throwing Proxy never throws', () => {
+    const hostileDetails = new Proxy(
+      {},
+      {
+        getOwnPropertyDescriptor() {
+          throw new Error('trap boom');
+        },
+      },
+    );
+    let picked;
+    expect(() => {
+      picked = pickWhitelistedDetails(hostileDetails);
+    }).not.toThrow();
+    expect(picked).toBeUndefined();
+  });
+});
+
+/**
+ * Unit tests — `error.details` is read at the `responses.error` call site
+ * ONE FRAME ABOVE `pickWhitelistedDetails` (finding 4, 2026-09 review round).
+ * A throwing `details` accessor on the error object itself (not merely on a
+ * property nested inside `details`) crashes that read before it ever reaches
+ * the picker's own try/catch, losing the request's real status/message to
+ * whatever generic handler catches the escaped exception. An explicit
+ * `description` argument is passed so the (separately unguarded,
+ * out-of-scope) `getDescription` read of `err?.details` is never reached —
+ * isolating this test to the exact line 255 read this fix protects.
+ */
+describe('responses.error — a throwing `details` accessor on the error object itself does not crash the response (finding 4):', () => {
+  let originalNodeEnv;
+
+  beforeEach(() => {
+    originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  test('an AppError whose `details` getter throws does not crash responses.error — status/message still sent', () => {
+    const res = buildRes();
+    const err = new AppError('Meter exhausted', { status: 402 });
+    Object.defineProperty(err, 'details', {
+      configurable: true,
+      get() {
+        throw new Error('boom from a getter');
+      },
+    });
+    expect(() => responses.error(res, 402, 'Meter exhausted', 'explicit description')(err)).not.toThrow();
+    expect(res._status).toBe(402);
+    expect(res._body.message).toBe('Meter exhausted');
+    expect(res._body.details).toBeUndefined();
+  });
 });
 
 /**
@@ -325,6 +421,43 @@ describe('buildWhitelist — config-provided whitelist extension sanitation (fin
     expect([...buildWhitelist(null)].sort()).toEqual([...BUILT_INS].sort());
     expect([...buildWhitelist(undefined)].sort()).toEqual([...BUILT_INS].sort());
   });
+
+  // Finding 2 (2026-09 review round): `config/index.js`'s DEVKIT_NODE_* array
+  // parsing splits on `,` without trimming, so an operator-written
+  // `"[upgradeUrl, planTier]"` produces a `' planTier'` (leading-space)
+  // element. Left untrimmed, that element becomes a DEAD whitelist entry: it
+  // can never match a real (unpadded) `details` property name, and
+  // `pickWhitelistedDetails` drops the key with no warning. Fixed at the
+  // `sanitizeConfigList` consumer, NOT at `config/index.js`'s splitting
+  // (shared infra, out of scope).
+  test('trims space-padded config entries so they match the real (unpadded) property name', () => {
+    const whitelist = buildWhitelist([' planTier', 'quotaName ', '  bothSides  ']);
+    expect(whitelist.has('planTier')).toBe(true);
+    expect(whitelist.has('quotaName')).toBe(true);
+    expect(whitelist.has('bothSides')).toBe(true);
+    // The untrimmed (space-padded) forms must NOT also linger in the set.
+    expect(whitelist.has(' planTier')).toBe(false);
+    expect(whitelist.has('quotaName ')).toBe(false);
+    expect(whitelist.has('  bothSides  ')).toBe(false);
+  });
+
+  test('end-to-end: whitelist built from an UNTRIMMED, comma-split raw value (config/index.js#146 shape) still picks up real property values', () => {
+    // Reproduces the exact reported shape: `config/index.js`'s env-var
+    // parsing splits `"[upgradeUrl, planTier, quotaName]"` on `,` WITHOUT
+    // trimming, so the raw array handed to `buildWhitelist` is
+    // `['upgradeUrl', ' planTier', ' quotaName']`.
+    const rawSplitArray = '[upgradeUrl, planTier, quotaName]'.slice(1, -1).split(',');
+    expect(rawSplitArray).toEqual(['upgradeUrl', ' planTier', ' quotaName']);
+    const whitelist = buildWhitelist(rawSplitArray);
+    const picked = pickWhitelistedDetails({ planTier: 'pro', quotaName: 'scraps' }, whitelist);
+    expect(picked).toEqual({ planTier: 'pro', quotaName: 'scraps' });
+  });
+
+  test('drops entries that are empty (or all-whitespace) after trimming', () => {
+    const whitelist = buildWhitelist([' ', '   ', 'realKey']);
+    const extras = [...whitelist].filter((key) => !BUILT_INS.includes(key));
+    expect(extras).toEqual(['realKey']);
+  });
 });
 
 /**
@@ -356,5 +489,63 @@ describe('pickWhitelistedDetails — null-prototype belt-and-braces (finding 2):
     expect(Object.getPrototypeOf(picked)).toBeNull();
     expect(Object.prototype.hasOwnProperty.call(picked, '__proto__')).toBe(true);
     expect(picked.__proto__).toBe('not-an-object-marker');
+  });
+});
+
+/**
+ * Unit tests — the `config.errors.detailsWhitelist` -> `buildWhitelist` WIRING
+ * line itself (finding 1, 2026-09 review round). Every test above either
+ * hand-passes a whitelist `Set` to `pickWhitelistedDetails`, or hand-calls
+ * `buildWhitelist(someArray)` directly — none of them exercise the ONE line
+ * in `responses.js` (`const DETAILS_WHITELIST = buildWhitelist(config?.errors
+ * ?.detailsWhitelist);`) that actually reads config and feeds it into the
+ * module-level singleton `responses.error` uses by default. That line runs
+ * once at module-evaluation time, so reaching it requires a FRESH module
+ * instance under a mocked `config/index.js` — `jest.resetModules()` +
+ * `jest.unstable_mockModule()` + a dynamic `import()`, the same house
+ * pattern `redactUrl.unit.tests.js`'s "redactUrl config sourcing" describe
+ * block uses for the identical problem (a module-load-time config read).
+ * `config/index.js` is mocked down to `{ default: {...} }` (no named
+ * exports) to match how ~100 other test files in this repo mock it.
+ */
+describe('DETAILS_WHITELIST — config.errors.detailsWhitelist wiring reaches the module singleton (finding 1):', () => {
+  let originalNodeEnv;
+
+  beforeEach(() => {
+    originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+    jest.resetModules();
+  });
+
+  /**
+   * Load a fresh instance of responses.js under a given mocked config.
+   * @param {Object|undefined} mockConfig - the value `config/index.js` default-exports
+   * @returns {Promise<Object>} the freshly-loaded module's default export
+   */
+  const loadResponsesWithConfig = async (mockConfig) => {
+    jest.resetModules();
+    jest.unstable_mockModule('../../../config/index.js', () => ({ default: mockConfig }));
+    const mod = await import('../responses.js');
+    return mod.default;
+  };
+
+  test('a key placed at config.errors.detailsWhitelist reaches the effective whitelist responses.error uses by default', async () => {
+    const freshResponses = await loadResponsesWithConfig({ errors: { detailsWhitelist: ['wiredExtraKey'] } });
+    const res = buildRes();
+    const err = new AppError('boom', { status: 500, details: { wiredExtraKey: 'reached-via-config-wiring' } });
+    freshResponses.error(res, 500)(err);
+    expect(res._body.details).toEqual({ wiredExtraKey: 'reached-via-config-wiring' });
+  });
+
+  test('a missing config.errors leaves exactly the built-in defaults wired in (no config-extended key present)', async () => {
+    const freshResponses = await loadResponsesWithConfig({});
+    const res = buildRes();
+    const err = new AppError('boom', { status: 500, details: { wiredExtraKey: 'should-not-appear', upgradeUrl: '/billing/plans' } });
+    freshResponses.error(res, 500)(err);
+    expect(res._body.details).toEqual({ upgradeUrl: '/billing/plans' });
   });
 });

--- a/lib/helpers/unsafeKeys.js
+++ b/lib/helpers/unsafeKeys.js
@@ -1,0 +1,22 @@
+/**
+ * Property names that must never be used as an object key when the value is
+ * about to be merged onto / assigned onto another object, or serialized:
+ * assigning `picked['__proto__'] = x` on a plain object reassigns its
+ * PROTOTYPE (via the inherited accessor on `Object.prototype`) instead of
+ * creating an own property, and `constructor`/`prototype` are the classic
+ * adjacent prototype-pollution vectors.
+ *
+ * Single source of truth, imported by BOTH `config/index.js#deepMerge` (the
+ * config-merge guard) and `lib/helpers/responses.js#sanitizeConfigList` (the
+ * details-whitelist config guard) — never re-declared at either call site, so
+ * the two guards cannot silently drift apart. Deliberately its own module
+ * rather than a named export of `config/index.js`: that module is mocked
+ * down to `{ default: {...} }` (no named exports) across ~100 test files via
+ * `jest.unstable_mockModule`, so any shared helper adding a required named
+ * import from it breaks every one of those mocks at module-link time,
+ * regardless of whether the mocked test path exercises the new export.
+ * @readonly
+ */
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+export default UNSAFE_KEYS;

--- a/modules/billing/config/billing.development.config.js
+++ b/modules/billing/config/billing.development.config.js
@@ -36,6 +36,9 @@ const config = {
     /**
      * URL the front-end should redirect users to when quota is exhausted or past_due.
      * Used by middleware error responses (METER_EXHAUSTED, QUOTA_EXCEEDED).
+     * Capped at 200 chars in production (lib/helpers/responses.js#MAX_DETAIL_VALUE_LENGTH) —
+     * a longer absolute URL is silently dropped from the production response there,
+     * even though dev/test still show it via the raw-error blob.
      */
     upgradeUrl: '/billing/plans',
     /**


### PR DESCRIPTION
## What

`lib/helpers/responses.js` serialized `AppError.details` **only** outside production. Billing/quota errors (402) attach an upgrade URL and a machine-readable `type` there, so a production API client — a CLI, an agent — received a bare message and could neither offer the upgrade path nor branch on the error type.

This adds an **opt-in, exact-key whitelist** of production-safe detail keys (`upgradeUrl`, `type`, `retryAfter`), serialized in every environment. Every other key stays dev-only, exactly as before.

A downstream project can extend the list **additively** through `config.errors.detailsWhitelist`. It can never shrink it, replace it, or invert it into a denylist.

## Why it is shaped this way

- **The picker iterates the whitelist, not `details`' keys.** An unknown key is never looked at, let alone copied — so it fails closed by construction rather than by filtering.
- **Values are validated, not just keys.** Only `null`, a boolean, a finite number, or a string of at most 200 characters survives. This matters because the picker does not only receive curated billing details: eight pre-existing call sites hand it a raw caught exception (`details: err`) in `auth.controller.js` and `uploads.repository.js`. Without value validation, a nested object under a whitelisted key shipped wholesale — demonstrated against the shipped defaults with no config change.
- **A throwing getter is dropped, not propagated.** Reading a hostile `details` value must never abort the response; the remaining whitelisted keys are still picked.
- **The picked object has a null prototype**, and `__proto__` / `constructor` / `prototype` are rejected from the config list.
- **`config/index.js` is left undeclared on purpose.** `deepMerge` replaces arrays wholesale, so declaring a base array in `config/defaults/development.config.js` would clobber a downstream's extension instead of unioning with it. Documented as a comment there, matching the existing `log.sensitiveQueryKeys` precedent.

## `lib/helpers/unsafeKeys.js` (new)

`config/index.js`'s `deepMerge` already had an unsafe-key guard. Importing it directly was attempted and **broke 65 tests across 7 suites**: roughly 100 test files mock `config/index.js` down to `{ default: {...} }`, and ESM statically links named imports whether or not a given test path uses them. The Set is therefore extracted into a leaf module both sides import — one source of truth, with no change to the export surface of a heavily-mocked module.

## The 200-character cap

`upgradeUrl` is documented as an internal app route and defaults to `/billing/plans`; a realistic absolute URL with tracking parameters measures ~90-100 characters. The cap exists to bound a *raw error's* string, not to constrain that config value.

No runtime warning is emitted on drop, deliberately: `isSafeDetailValue` cannot distinguish a config-sourced `upgradeUrl` from a caught exception's `.type`, so a warn would fire on every OAuth or upload error carrying a matching key — noise, not signal. A boot-time check of a billing config value inside a generic stack helper would bake domain knowledge into shared code. The gap that was real is that nothing told a downstream engineer the cap exists, so `billing.development.config.js` now documents it at the override site.

## Verification

Three independent cold-context review rounds plus a security pass. The first round **BLOCKED** this — the nested-object leak and the `__proto__` config vector were both found by *executing* the shipped code, not by reading it. Notably, a security review that reasoned about the same lines rated it LOW; the reviewer that ran adversarial inputs rated it high.

- Lint clean, verified through a raw shell.
- 2414 unit tests green; `responses.js` at 98.86 / 97.05 / 100 / 100. `unsafeKeys.js` 100% across the board. No threshold touched (this repo gates coverage via Codecov).
- 14 of the 17 whitelist tests were proven red against the pre-fix code before turning green; the other 3 lock in pre-existing invariants and are labelled as such rather than claimed as regression proof.

## Follow-ups — pre-existing, out of this diff, deliberately untouched

- `modules/billing/controllers/billing.controller.js:26` bypasses `responses.error` entirely and ships `err.message` / `err.portalUrl` unconditionally in every environment, in the same billing domain this PR protects. Harmless today (hardcoded string + a legitimate portal URL), ungated tomorrow.
- `getDescription` already places `details.message` into the `description` field in every environment including production — verified live. Combined with the eight `details: err` call sites, raw error messages reach production responses today, independently of this change.
- Those eight call sites pass an uncurated caught exception as `details`. Value validation bounds the damage; it does not make the pattern correct.

Closes #3958

https://claude.ai/code/session_0185ELiCjZaBJx8PH4xoSsZb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Error responses can now include selected safe details, such as upgrade links, error types, and retry timing.
  - Supported detail fields can be extended through configuration while retaining built-in safeguards.

- **Bug Fixes**
  - Unsafe, malformed, oversized, or unexpected error details are excluded from serialized responses.
  - Configuration merging now prevents prototype-related keys from altering application behavior.

- **Documentation**
  - Clarified production limits and handling for billing upgrade URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->