### PR TITLE
refactor(billing): share the cron bootstrap preamble

### DIFF
--- a/modules/billing/crons/billing.dunningSweep.js
+++ b/modules/billing/crons/billing.dunningSweep.js
@@ -31,6 +31,11 @@ const {
   LOCK_NAME,
   LOCK_TTL_MS,
 } = await bootstrapCron({
+  /**
+   * Gate predicate for this cron — true when metered billing is enabled.
+   * @param {object} config - Loaded app config.
+   * @returns {boolean} True when config.billing.meterMode is truthy.
+   */
   isEnabled: (config) => Boolean(config?.billing?.meterMode),
   gateMessage: '[cron.dunningSweep] meterMode disabled — skipping.',
   lockName: 'billing.dunningSweep',

--- a/modules/billing/crons/billing.dunningSweep.js
+++ b/modules/billing/crons/billing.dunningSweep.js
@@ -18,32 +18,24 @@
  */
 
 import { randomUUID } from 'node:crypto';
+import { bootstrapCron } from '../lib/billing.cron-utils.js';
 
-process.env.NODE_ENV = process.env.NODE_ENV || 'development';
-
-const [
-  { default: config },
-  { default: mongooseService },
-  { default: logger },
-  { applyJitter },
-  { getCronJitterMaxMs, getDunningThresholdDays },
-  { acquireLock, releaseLock },
-] = await Promise.all([
-  import('../../../config/index.js'),
-  import('../../../lib/services/mongoose.js'),
-  import('../../../lib/services/logger.js'),
-  import('../lib/billing.cron-utils.js'),
-  import('../lib/billing.constants.js'),
-  import('../../../lib/services/distributedLock.js'),
-]);
-
-if (!config?.billing?.meterMode) {
-  logger.info('[cron.dunningSweep] meterMode disabled — skipping.');
-  process.exit(0);
-}
-
-const LOCK_NAME = 'billing.dunningSweep';
-const LOCK_TTL_MS = 15 * 60 * 1000; // 15 min
+const {
+  mongooseService,
+  logger,
+  applyJitter,
+  getCronJitterMaxMs,
+  getDunningThresholdDays,
+  acquireLock,
+  releaseLock,
+  LOCK_NAME,
+  LOCK_TTL_MS,
+} = await bootstrapCron({
+  isEnabled: (config) => Boolean(config?.billing?.meterMode),
+  gateMessage: '[cron.dunningSweep] meterMode disabled — skipping.',
+  lockName: 'billing.dunningSweep',
+  lockTtlMs: 15 * 60 * 1000, // 15 min
+});
 
 const startMs = Date.now();
 logger.info('[cron.dunningSweep] start');

--- a/modules/billing/crons/billing.extrasExpiration.js
+++ b/modules/billing/crons/billing.extrasExpiration.js
@@ -13,32 +13,23 @@
  */
 
 import { randomUUID } from 'node:crypto';
+import { bootstrapCron } from '../lib/billing.cron-utils.js';
 
-process.env.NODE_ENV = process.env.NODE_ENV || 'development';
-
-const [
-  { default: config },
-  { default: mongooseService },
-  { default: logger },
-  { applyJitter },
-  { getCronJitterMaxMs },
-  { acquireLock, releaseLock },
-] = await Promise.all([
-  import('../../../config/index.js'),
-  import('../../../lib/services/mongoose.js'),
-  import('../../../lib/services/logger.js'),
-  import('../lib/billing.cron-utils.js'),
-  import('../lib/billing.constants.js'),
-  import('../../../lib/services/distributedLock.js'),
-]);
-
-if (!config?.billing?.meterMode) {
-  logger.info('[cron.extrasExpiration] meterMode disabled — skipping.');
-  process.exit(0);
-}
-
-const LOCK_NAME = 'billing.extrasExpiration';
-const LOCK_TTL_MS = 5 * 60 * 1000; // 5 min
+const {
+  mongooseService,
+  logger,
+  applyJitter,
+  getCronJitterMaxMs,
+  acquireLock,
+  releaseLock,
+  LOCK_NAME,
+  LOCK_TTL_MS,
+} = await bootstrapCron({
+  isEnabled: (config) => Boolean(config?.billing?.meterMode),
+  gateMessage: '[cron.extrasExpiration] meterMode disabled — skipping.',
+  lockName: 'billing.extrasExpiration',
+  lockTtlMs: 5 * 60 * 1000, // 5 min
+});
 
 const startMs = Date.now();
 logger.info('[cron.extrasExpiration] start');

--- a/modules/billing/crons/billing.extrasExpiration.js
+++ b/modules/billing/crons/billing.extrasExpiration.js
@@ -25,6 +25,11 @@ const {
   LOCK_NAME,
   LOCK_TTL_MS,
 } = await bootstrapCron({
+  /**
+   * Gate predicate for this cron — true when metered billing is enabled.
+   * @param {object} config - Loaded app config.
+   * @returns {boolean} True when config.billing.meterMode is truthy.
+   */
   isEnabled: (config) => Boolean(config?.billing?.meterMode),
   gateMessage: '[cron.extrasExpiration] meterMode disabled — skipping.',
   lockName: 'billing.extrasExpiration',

--- a/modules/billing/crons/billing.reconcile.js
+++ b/modules/billing/crons/billing.reconcile.js
@@ -28,6 +28,11 @@ const {
   LOCK_NAME,
   LOCK_TTL_MS,
 } = await bootstrapCron({
+  /**
+   * Gate predicate for this cron — true when metered billing is enabled.
+   * @param {object} config - Loaded app config.
+   * @returns {boolean} True when config.billing.meterMode is truthy.
+   */
   isEnabled: (config) => Boolean(config?.billing?.meterMode),
   gateMessage: '[cron.reconcile] meterMode disabled — skipping.',
   lockName: 'billing.reconcile',

--- a/modules/billing/crons/billing.reconcile.js
+++ b/modules/billing/crons/billing.reconcile.js
@@ -16,32 +16,23 @@
  */
 
 import { randomUUID } from 'node:crypto';
+import { bootstrapCron } from '../lib/billing.cron-utils.js';
 
-process.env.NODE_ENV = process.env.NODE_ENV || 'development';
-
-const [
-  { default: config },
-  { default: mongooseService },
-  { default: logger },
-  { applyJitter },
-  { getCronJitterMaxMs },
-  { acquireLock, releaseLock },
-] = await Promise.all([
-  import('../../../config/index.js'),
-  import('../../../lib/services/mongoose.js'),
-  import('../../../lib/services/logger.js'),
-  import('../lib/billing.cron-utils.js'),
-  import('../lib/billing.constants.js'),
-  import('../../../lib/services/distributedLock.js'),
-]);
-
-if (!config?.billing?.meterMode) {
-  logger.info('[cron.reconcile] meterMode disabled — skipping.');
-  process.exit(0);
-}
-
-const LOCK_NAME = 'billing.reconcile';
-const LOCK_TTL_MS = 30 * 60 * 1000; // 30 min — reconcile paginates Stripe per subscription
+const {
+  mongooseService,
+  logger,
+  applyJitter,
+  getCronJitterMaxMs,
+  acquireLock,
+  releaseLock,
+  LOCK_NAME,
+  LOCK_TTL_MS,
+} = await bootstrapCron({
+  isEnabled: (config) => Boolean(config?.billing?.meterMode),
+  gateMessage: '[cron.reconcile] meterMode disabled — skipping.',
+  lockName: 'billing.reconcile',
+  lockTtlMs: 30 * 60 * 1000, // 30 min — reconcile paginates Stripe per subscription
+});
 
 const startMs = Date.now();
 logger.info('[cron.reconcile] start');

--- a/modules/billing/crons/billing.referralReconcile.js
+++ b/modules/billing/crons/billing.referralReconcile.js
@@ -17,32 +17,24 @@
  */
 
 import { randomUUID } from 'node:crypto';
+import { bootstrapCron } from '../lib/billing.cron-utils.js';
 
-process.env.NODE_ENV = process.env.NODE_ENV || 'development';
-
-const [
-  { default: config },
-  { default: mongooseService },
-  { default: logger },
-  { applyJitter },
-  { getCronJitterMaxMs },
-  { acquireLock, releaseLock },
-] = await Promise.all([
-  import('../../../config/index.js'),
-  import('../../../lib/services/mongoose.js'),
-  import('../../../lib/services/logger.js'),
-  import('../lib/billing.cron-utils.js'),
-  import('../lib/billing.constants.js'),
-  import('../../../lib/services/distributedLock.js'),
-]);
-
-if (!config?.billing?.referral?.enabled) {
-  logger.info('[cron.referralReconcile] referral disabled — skipping.');
-  process.exit(0);
-}
-
-const LOCK_NAME = 'billing.referralReconcile';
-const LOCK_TTL_MS = 10 * 60 * 1000; // 10 min
+const {
+  config,
+  mongooseService,
+  logger,
+  applyJitter,
+  getCronJitterMaxMs,
+  acquireLock,
+  releaseLock,
+  LOCK_NAME,
+  LOCK_TTL_MS,
+} = await bootstrapCron({
+  isEnabled: (config) => Boolean(config?.billing?.referral?.enabled),
+  gateMessage: '[cron.referralReconcile] referral disabled — skipping.',
+  lockName: 'billing.referralReconcile',
+  lockTtlMs: 10 * 60 * 1000, // 10 min
+});
 
 const startMs = Date.now();
 logger.info('[cron.referralReconcile] start');

--- a/modules/billing/crons/billing.referralReconcile.js
+++ b/modules/billing/crons/billing.referralReconcile.js
@@ -30,6 +30,11 @@ const {
   LOCK_NAME,
   LOCK_TTL_MS,
 } = await bootstrapCron({
+  /**
+   * Gate predicate for this cron — true when the referral program is enabled.
+   * @param {object} config - Loaded app config.
+   * @returns {boolean} True when config.billing.referral.enabled is truthy.
+   */
   isEnabled: (config) => Boolean(config?.billing?.referral?.enabled),
   gateMessage: '[cron.referralReconcile] referral disabled — skipping.',
   lockName: 'billing.referralReconcile',

--- a/modules/billing/crons/billing.weeklyReset.js
+++ b/modules/billing/crons/billing.weeklyReset.js
@@ -24,6 +24,11 @@ const {
   LOCK_NAME,
   LOCK_TTL_MS,
 } = await bootstrapCron({
+  /**
+   * Gate predicate for this cron — true when metered billing is enabled.
+   * @param {object} config - Loaded app config.
+   * @returns {boolean} True when config.billing.meterMode is truthy.
+   */
   isEnabled: (config) => Boolean(config?.billing?.meterMode),
   gateMessage: '[cron.weeklyReset] meterMode disabled — skipping.',
   lockName: 'billing.weeklyReset',

--- a/modules/billing/crons/billing.weeklyReset.js
+++ b/modules/billing/crons/billing.weeklyReset.js
@@ -12,32 +12,23 @@
  */
 
 import { randomUUID } from 'node:crypto';
+import { bootstrapCron } from '../lib/billing.cron-utils.js';
 
-process.env.NODE_ENV = process.env.NODE_ENV || 'development';
-
-const [
-  { default: config },
-  { default: mongooseService },
-  { default: logger },
-  { applyJitter },
-  { getCronJitterMaxMs },
-  { acquireLock, releaseLock },
-] = await Promise.all([
-  import('../../../config/index.js'),
-  import('../../../lib/services/mongoose.js'),
-  import('../../../lib/services/logger.js'),
-  import('../lib/billing.cron-utils.js'),
-  import('../lib/billing.constants.js'),
-  import('../../../lib/services/distributedLock.js'),
-]);
-
-if (!config?.billing?.meterMode) {
-  logger.info('[cron.weeklyReset] meterMode disabled — skipping.');
-  process.exit(0);
-}
-
-const LOCK_NAME = 'billing.weeklyReset';
-const LOCK_TTL_MS = 10 * 60 * 1000; // 10 min
+const {
+  mongooseService,
+  logger,
+  applyJitter,
+  getCronJitterMaxMs,
+  acquireLock,
+  releaseLock,
+  LOCK_NAME,
+  LOCK_TTL_MS,
+} = await bootstrapCron({
+  isEnabled: (config) => Boolean(config?.billing?.meterMode),
+  gateMessage: '[cron.weeklyReset] meterMode disabled — skipping.',
+  lockName: 'billing.weeklyReset',
+  lockTtlMs: 10 * 60 * 1000, // 10 min
+});
 
 const startMs = Date.now();
 logger.info('[cron.weeklyReset] start');

--- a/modules/billing/lib/billing.cron-utils.js
+++ b/modules/billing/lib/billing.cron-utils.js
@@ -20,17 +20,7 @@ export const applyJitter = async (maxMs) => {
 
 /**
  * @function bootstrapCron
- * @description Shared bootstrap preamble for billing cron scripts: sets the NODE_ENV
- *              default, loads the standard cron dependencies (config, mongooseService,
- *              logger, distributedLock, and every named export of billing.constants.js)
- *              in parallel, then applies the cron's config gate. The gate predicate and
- *              message are parameters — not uniform across crons (referralReconcile
- *              gates on `billing.referral.enabled`, the rest on `billing.meterMode`).
- *              Constants are spread wholesale (not just `getCronJitterMaxMs`) so a
- *              cron needing a different one (e.g. `getDunningThresholdDays`) still gets
- *              it without this function enumerating every call site. `lockName`/
- *              `lockTtlMs` are echoed back as `LOCK_NAME`/`LOCK_TTL_MS` so the per-cron
- *              lock literals live at the call site next to the values they describe.
+ * @description Shared bootstrap preamble for billing cron scripts: validates params, loads the standard cron dependencies in parallel, then applies the cron's config gate.
  * @param {object} params
  * @param {(config: object) => boolean} params.isEnabled - Gate predicate; receives the
  *   loaded config and returns true when the cron should proceed. Required — must be a

--- a/modules/billing/lib/billing.cron-utils.js
+++ b/modules/billing/lib/billing.cron-utils.js
@@ -33,13 +33,23 @@ export const applyJitter = async (maxMs) => {
  *              lock literals live at the call site next to the values they describe.
  * @param {object} params
  * @param {(config: object) => boolean} params.isEnabled - Gate predicate; receives the
- *   loaded config and returns true when the cron should proceed.
+ *   loaded config and returns true when the cron should proceed. Required — must be a
+ *   function, checked before any dynamic import runs.
  * @param {string} params.gateMessage - Logged (via `logger.info`) when the gate is
- *   closed, immediately before the process exits with code 0.
+ *   closed, immediately before the process exits with code 0. Required — every cron
+ *   has something to say when it's skipped, so this is validated like the rest rather
+ *   than left to log `undefined` silently.
  * @param {string} params.lockName - Distributed lock name for this cron, echoed back
- *   as `LOCK_NAME`.
+ *   as `LOCK_NAME`. Required non-empty string — an empty/missing name would still let
+ *   `acquireLock` return `true` for every caller (no real mutual exclusion), so this is
+ *   validated here rather than relying on a downstream check in a different module.
  * @param {number} params.lockTtlMs - Distributed lock TTL in ms for this cron, echoed
- *   back as `LOCK_TTL_MS`.
+ *   back as `LOCK_TTL_MS`. Required positive finite number.
+ * @throws {Error} Rejects before any dynamic import or other side effect runs, if
+ *   `isEnabled` is not a function, `gateMessage`/`lockName` is not a non-empty string,
+ *   or `lockTtlMs` is not a positive finite number. A cron that cannot lock must not
+ *   run — failing loudly at startup beats a cron that looks healthy but never locks
+ *   anything.
  * @returns {Promise<object|null>} `{ config, mongooseService, logger, applyJitter,
  *   acquireLock, releaseLock, LOCK_NAME, LOCK_TTL_MS, ...billingConstants }` when the
  *   gate is open, else `null` (the closed-gate path calls `process.exit(0)` first, so
@@ -47,6 +57,21 @@ export const applyJitter = async (maxMs) => {
  *   `process.exit`).
  */
 export const bootstrapCron = async ({ isEnabled, gateMessage, lockName, lockTtlMs }) => {
+  if (typeof isEnabled !== 'function') {
+    throw new Error(`bootstrapCron: isEnabled must be a function, received ${typeof isEnabled}`);
+  }
+  if (typeof gateMessage !== 'string' || gateMessage.length === 0) {
+    throw new Error(`bootstrapCron: gateMessage must be a non-empty string, received ${JSON.stringify(gateMessage)}`);
+  }
+  if (typeof lockName !== 'string' || lockName.length === 0) {
+    throw new Error(`bootstrapCron: lockName must be a non-empty string, received ${JSON.stringify(lockName)}`);
+  }
+  if (!Number.isFinite(lockTtlMs) || lockTtlMs <= 0) {
+    // String(), not JSON.stringify() — JSON.stringify(Infinity/NaN) both collapse to
+    // the string "null", which would misreport exactly the values this guards against.
+    throw new Error(`bootstrapCron: lockTtlMs must be a positive finite number, received ${String(lockTtlMs)}`);
+  }
+
   process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 
   const [

--- a/modules/billing/lib/billing.cron-utils.js
+++ b/modules/billing/lib/billing.cron-utils.js
@@ -18,6 +18,71 @@ export const applyJitter = async (maxMs) => {
   return delayMs;
 };
 
+/**
+ * @function bootstrapCron
+ * @description Shared bootstrap preamble for billing cron scripts: sets the NODE_ENV
+ *              default, loads the standard cron dependencies (config, mongooseService,
+ *              logger, distributedLock, and every named export of billing.constants.js)
+ *              in parallel, then applies the cron's config gate. The gate predicate and
+ *              message are parameters — not uniform across crons (referralReconcile
+ *              gates on `billing.referral.enabled`, the rest on `billing.meterMode`).
+ *              Constants are spread wholesale (not just `getCronJitterMaxMs`) so a
+ *              cron needing a different one (e.g. `getDunningThresholdDays`) still gets
+ *              it without this function enumerating every call site. `lockName`/
+ *              `lockTtlMs` are echoed back as `LOCK_NAME`/`LOCK_TTL_MS` so the per-cron
+ *              lock literals live at the call site next to the values they describe.
+ * @param {object} params
+ * @param {(config: object) => boolean} params.isEnabled - Gate predicate; receives the
+ *   loaded config and returns true when the cron should proceed.
+ * @param {string} params.gateMessage - Logged (via `logger.info`) when the gate is
+ *   closed, immediately before the process exits with code 0.
+ * @param {string} params.lockName - Distributed lock name for this cron, echoed back
+ *   as `LOCK_NAME`.
+ * @param {number} params.lockTtlMs - Distributed lock TTL in ms for this cron, echoed
+ *   back as `LOCK_TTL_MS`.
+ * @returns {Promise<object|null>} `{ config, mongooseService, logger, applyJitter,
+ *   acquireLock, releaseLock, LOCK_NAME, LOCK_TTL_MS, ...billingConstants }` when the
+ *   gate is open, else `null` (the closed-gate path calls `process.exit(0)` first, so
+ *   this return is unreachable in a real run — it only matters to a test that mocks
+ *   `process.exit`).
+ */
+export const bootstrapCron = async ({ isEnabled, gateMessage, lockName, lockTtlMs }) => {
+  process.env.NODE_ENV = process.env.NODE_ENV || 'development';
+
+  const [
+    { default: config },
+    { default: mongooseService },
+    { default: logger },
+    constants,
+    { acquireLock, releaseLock },
+  ] = await Promise.all([
+    import('../../../config/index.js'),
+    import('../../../lib/services/mongoose.js'),
+    import('../../../lib/services/logger.js'),
+    import('./billing.constants.js'),
+    import('../../../lib/services/distributedLock.js'),
+  ]);
+
+  if (!isEnabled(config)) {
+    logger.info(gateMessage);
+    process.exit(0);
+    return null;
+  }
+
+  return {
+    ...constants,
+    config,
+    mongooseService,
+    logger,
+    applyJitter,
+    acquireLock,
+    releaseLock,
+    LOCK_NAME: lockName,
+    LOCK_TTL_MS: lockTtlMs,
+  };
+};
+
 export default {
   applyJitter,
+  bootstrapCron,
 };

--- a/modules/billing/tests/billing.cron-utils.unit.tests.js
+++ b/modules/billing/tests/billing.cron-utils.unit.tests.js
@@ -39,6 +39,7 @@ describe('billing cron utils — bootstrapCron:', () => {
   let mockMongooseService;
   let mockAcquireLock;
   let mockReleaseLock;
+  let configFactory;
   let exitSpy;
   const originalNodeEnv = process.env.NODE_ENV;
 
@@ -57,7 +58,11 @@ describe('billing cron utils — bootstrapCron:', () => {
     // distributedLock.js resolve identically from either sibling dir). billing.constants.js
     // is deliberately NOT mocked — its real named exports are what proves the "everything
     // else each cron currently destructures" contract (e.g. getDunningThresholdDays).
-    jest.unstable_mockModule('../../../config/index.js', () => ({ default: mockConfig }));
+    // Wrapped in jest.fn so the input-validation tests can assert this factory was
+    // never invoked — i.e. that validation actually runs before the dynamic import,
+    // not just that some other symptom (lock/exit) never fires.
+    configFactory = jest.fn(() => ({ default: mockConfig }));
+    jest.unstable_mockModule('../../../config/index.js', configFactory);
     jest.unstable_mockModule('../../../lib/services/mongoose.js', () => ({ default: mockMongooseService }));
     jest.unstable_mockModule('../../../lib/services/logger.js', () => ({ default: mockLogger }));
     jest.unstable_mockModule('../../../lib/services/distributedLock.js', () => ({
@@ -151,5 +156,80 @@ describe('billing cron utils — bootstrapCron:', () => {
 
     expect(exitSpy).not.toHaveBeenCalled();
     expect(result.LOCK_NAME).toBe('billing.referralReconcile');
+  });
+
+  describe('input validation:', () => {
+    // Baseline valid params — each test overrides exactly one field with an invalid
+    // value so a thrown error can only be about the field under test.
+    const validParams = () => ({
+      isEnabled: () => true,
+      gateMessage: '[cron.probe] disabled — skipping.',
+      lockName: 'billing.probe',
+      lockTtlMs: 1000,
+    });
+
+    // Drop one key from a fresh validParams() copy — used to simulate a missing param
+    // without an unused destructured binding.
+    const withoutKey = (key) => {
+      const params = validParams();
+      delete params[key];
+      return params;
+    };
+
+    test('rejects a missing lockName', async () => {
+      await expect(bootstrapCron(withoutKey('lockName'))).rejects.toThrow(/lockName/);
+    });
+
+    test('rejects an empty-string lockName', async () => {
+      await expect(bootstrapCron({ ...validParams(), lockName: '' })).rejects.toThrow(/lockName/);
+    });
+
+    test('rejects a non-string lockName', async () => {
+      await expect(bootstrapCron({ ...validParams(), lockName: 42 })).rejects.toThrow(/lockName/);
+    });
+
+    test('rejects a missing lockTtlMs', async () => {
+      await expect(bootstrapCron(withoutKey('lockTtlMs'))).rejects.toThrow(/lockTtlMs/);
+    });
+
+    test('rejects a zero lockTtlMs', async () => {
+      await expect(bootstrapCron({ ...validParams(), lockTtlMs: 0 })).rejects.toThrow(/lockTtlMs/);
+    });
+
+    test('rejects a negative lockTtlMs', async () => {
+      await expect(bootstrapCron({ ...validParams(), lockTtlMs: -1000 })).rejects.toThrow(/lockTtlMs/);
+    });
+
+    test('rejects a non-finite lockTtlMs', async () => {
+      // Message assertions, not just /lockTtlMs/: JSON.stringify(Infinity/NaN) both
+      // collapse to "null", which would misreport the received value as null instead
+      // of Infinity/NaN — the whole point of this finding is error-message clarity.
+      await expect(bootstrapCron({ ...validParams(), lockTtlMs: Infinity })).rejects.toThrow(/lockTtlMs.*Infinity/);
+      await expect(bootstrapCron({ ...validParams(), lockTtlMs: NaN })).rejects.toThrow(/lockTtlMs.*NaN/);
+    });
+
+    test('rejects a non-function isEnabled', async () => {
+      await expect(bootstrapCron({ ...validParams(), isEnabled: 'not-a-function' })).rejects.toThrow(/isEnabled/);
+      await expect(bootstrapCron({ ...validParams(), isEnabled: undefined })).rejects.toThrow(/isEnabled/);
+    });
+
+    test('rejects a missing gateMessage', async () => {
+      await expect(bootstrapCron(withoutKey('gateMessage'))).rejects.toThrow(/gateMessage/);
+    });
+
+    test('rejects an empty-string gateMessage', async () => {
+      await expect(bootstrapCron({ ...validParams(), gateMessage: '' })).rejects.toThrow(/gateMessage/);
+    });
+
+    test('validation runs before the dynamic imports — the config module factory is never invoked', async () => {
+      // Guards against a regression that moves the checks after `Promise.all(...)`:
+      // mockAcquireLock/exitSpy alone wouldn't catch that (bootstrapCron never calls
+      // acquireLock itself — it returns it — and exitSpy only fires on the closed-gate
+      // path). Asserting the config factory itself was never called proves the dynamic
+      // import never ran, which is what "before any side effect" actually means.
+      await expect(bootstrapCron({ ...validParams(), lockName: '' })).rejects.toThrow(/lockName/);
+
+      expect(configFactory).not.toHaveBeenCalled();
+    });
   });
 });

--- a/modules/billing/tests/billing.cron-utils.unit.tests.js
+++ b/modules/billing/tests/billing.cron-utils.unit.tests.js
@@ -159,8 +159,11 @@ describe('billing cron utils — bootstrapCron:', () => {
   });
 
   describe('input validation:', () => {
-    // Baseline valid params — each test overrides exactly one field with an invalid
-    // value so a thrown error can only be about the field under test.
+    /**
+     * Baseline valid params — each test overrides exactly one field with an invalid
+     * value so a thrown error can only be about the field under test.
+     * @returns {{isEnabled: Function, gateMessage: string, lockName: string, lockTtlMs: number}} A fresh set of valid bootstrapCron params.
+     */
     const validParams = () => ({
       isEnabled: () => true,
       gateMessage: '[cron.probe] disabled — skipping.',
@@ -168,8 +171,12 @@ describe('billing cron utils — bootstrapCron:', () => {
       lockTtlMs: 1000,
     });
 
-    // Drop one key from a fresh validParams() copy — used to simulate a missing param
-    // without an unused destructured binding.
+    /**
+     * Drop one key from a fresh validParams() copy — used to simulate a missing param
+     * without an unused destructured binding.
+     * @param {string} key - Name of the param to omit.
+     * @returns {object} A validParams() copy with `key` deleted.
+     */
     const withoutKey = (key) => {
       const params = validParams();
       delete params[key];

--- a/modules/billing/tests/billing.cron-utils.unit.tests.js
+++ b/modules/billing/tests/billing.cron-utils.unit.tests.js
@@ -31,3 +31,125 @@ describe('billing cron utils:', () => {
     expect(randomInt).not.toHaveBeenCalled();
   });
 });
+
+describe('billing cron utils — bootstrapCron:', () => {
+  let bootstrapCron;
+  let mockConfig;
+  let mockLogger;
+  let mockMongooseService;
+  let mockAcquireLock;
+  let mockReleaseLock;
+  let exitSpy;
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    delete process.env.NODE_ENV;
+
+    mockConfig = { billing: { meterMode: true, referral: { enabled: false } } };
+    mockLogger = { info: jest.fn(), error: jest.fn() };
+    mockMongooseService = { loadModels: jest.fn(), connect: jest.fn(), disconnect: jest.fn() };
+    mockAcquireLock = jest.fn();
+    mockReleaseLock = jest.fn();
+
+    // Same resolved targets the crons themselves hit (config/services/distributedLock sit
+    // 3 levels above modules/billing/{lib,tests}/ alike — mongoose.js/logger.js/
+    // distributedLock.js resolve identically from either sibling dir). billing.constants.js
+    // is deliberately NOT mocked — its real named exports are what proves the "everything
+    // else each cron currently destructures" contract (e.g. getDunningThresholdDays).
+    jest.unstable_mockModule('../../../config/index.js', () => ({ default: mockConfig }));
+    jest.unstable_mockModule('../../../lib/services/mongoose.js', () => ({ default: mockMongooseService }));
+    jest.unstable_mockModule('../../../lib/services/logger.js', () => ({ default: mockLogger }));
+    jest.unstable_mockModule('../../../lib/services/distributedLock.js', () => ({
+      acquireLock: mockAcquireLock,
+      releaseLock: mockReleaseLock,
+    }));
+
+    ({ bootstrapCron } = await import('../lib/billing.cron-utils.js'));
+
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  test('defaults NODE_ENV to development when unset', async () => {
+    await bootstrapCron({
+      isEnabled: () => true,
+      gateMessage: 'unused',
+      lockName: 'billing.probe',
+      lockTtlMs: 1000,
+    });
+
+    expect(process.env.NODE_ENV).toBe('development');
+  });
+
+  test('leaves an explicit NODE_ENV untouched', async () => {
+    process.env.NODE_ENV = 'test';
+
+    await bootstrapCron({
+      isEnabled: () => true,
+      gateMessage: 'unused',
+      lockName: 'billing.probe',
+      lockTtlMs: 1000,
+    });
+
+    expect(process.env.NODE_ENV).toBe('test');
+  });
+
+  test('closed gate logs gateMessage and exits 0 without acquiring any lock', async () => {
+    const result = await bootstrapCron({
+      isEnabled: () => false,
+      gateMessage: '[cron.probe] disabled — skipping.',
+      lockName: 'billing.probe',
+      lockTtlMs: 1000,
+    });
+
+    expect(mockLogger.info).toHaveBeenCalledWith('[cron.probe] disabled — skipping.');
+    expect(exitSpy).toHaveBeenCalledWith(0);
+    expect(mockAcquireLock).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  test('open gate returns every binding a cron currently destructures, plus the echoed lock params', async () => {
+    const result = await bootstrapCron({
+      isEnabled: (config) => Boolean(config?.billing?.meterMode),
+      gateMessage: 'unused',
+      lockName: 'billing.dunningSweep',
+      lockTtlMs: 15 * 60 * 1000,
+    });
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(result.config).toBe(mockConfig);
+    expect(result.mongooseService).toBe(mockMongooseService);
+    expect(result.logger).toBe(mockLogger);
+    expect(result.acquireLock).toBe(mockAcquireLock);
+    expect(result.releaseLock).toBe(mockReleaseLock);
+    expect(result.LOCK_NAME).toBe('billing.dunningSweep');
+    expect(result.LOCK_TTL_MS).toBe(15 * 60 * 1000);
+    expect(typeof result.applyJitter).toBe('function');
+    // Real billing.constants.js exports — proves the spread carries every constant,
+    // not a hardcoded subset (the trap: dunningSweep alone also needs this one).
+    expect(typeof result.getCronJitterMaxMs).toBe('function');
+    expect(typeof result.getDunningThresholdDays).toBe('function');
+    expect(result.getDunningThresholdDays()).toBe(14); // DEFAULT_DUNNING_THRESHOLD_DAYS
+  });
+
+  test('gate predicate receives the loaded config — referral gate is independent of meterMode', async () => {
+    mockConfig.billing.meterMode = false;
+    mockConfig.billing.referral.enabled = true;
+
+    const result = await bootstrapCron({
+      isEnabled: (config) => Boolean(config?.billing?.referral?.enabled),
+      gateMessage: 'unused',
+      lockName: 'billing.referralReconcile',
+      lockTtlMs: 10 * 60 * 1000,
+    });
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(result.LOCK_NAME).toBe('billing.referralReconcile');
+  });
+});


### PR DESCRIPTION
## What

Five billing cron scripts repeated an identical ~25-line bootstrap preamble — a parallel import block, a `NODE_ENV` default, a config gate, and a lock name/TTL. Adding a sixth meant copying it a sixth time.

`bootstrapCron({ isEnabled, gateMessage, lockName, lockTtlMs })` now lives in `modules/billing/lib/billing.cron-utils.js` (which already held `applyJitter`), and all five crons call it.

## The three traps, and how each was handled

**The gate is not uniform.** Four crons gate on the meter-mode flag; `billing.referralReconcile` gates on the **referral-enabled** flag and logs a different message. Both the predicate and the log line are parameters, not hardcoded. Verified by running each cron with the two flags toggled independently against an unreachable Mongo: with meter-mode on and referral off, the four meter crons reach `[cron.X] start` while `referralReconcile` stays on `referral disabled — skipping.`; with the flags inverted, exactly the reverse. No cross-wiring.

**A missing destructured binding crashes at runtime while unit tests stay green.** Solved structurally rather than by enumeration: the helper spreads the whole constants namespace, so `dunningSweep`'s `getDunningThresholdDays` and `referralReconcile`'s `config` — and anything added later — cannot go missing. Verified by probing the returned object for every name destructured across all five files.

**The `NODE_ENV` default's position in the sequence matters.** `config/index.js` reads `process.env.NODE_ENV` at module-evaluation time, so the default has to be set before the imports resolve. Confirmed by instrumented probe that the ordering is unchanged, and by cross-branch runs with `NODE_ENV` unset producing the identical development-default warning.

## Behaviour equivalence

All five crons smoke-run with their flag off, against a real `origin/master` worktree and against this branch: **stdout, stderr and exit code byte-identical** in every case, including `referralReconcile`'s distinct message. Each of the five lock names and TTLs moved unchanged and all five remain distinct.

## Input validation (added after review)

Review found that `bootstrapCron` accepted a missing `lockName` silently: it echoed through as `LOCK_NAME: undefined`, and `acquireLock({ name: undefined, … })` returns `true` for *every* caller inside the TTL window — reproduced against a real Mongo. A sixth cron added later with a typo'd key would look like it was running normally while mutual exclusion was silently defeated; for `dunningSweep` (downgrades subscriptions) or `referralReconcile` (grants ledger credits) that means concurrent unlocked writes across pods.

All four parameters are now validated before any import runs, throwing an error that names the offending one. `gateMessage` turned out to have the same gap — an omitted one logged literal `undefined` on the closed-gate path.

## Tests

18 unit tests on the helper, 10 of which fail against the pre-validation code. Mutation-checked: unifying the gate reddens 2 tests, removing the `NODE_ENV` default reddens 1, replacing the constants spread with only `getCronJitterMaxMs` reddens 1, and dropping *only* `getDunningThresholdDays` from the spread reddens the same one — so that test asserts a real constant's actual value rather than a mock.

`npm run lint` clean; 2403 unit tests green; `billing.cron-utils.js` at 96.15 / 95.83 / 100 / 100. No threshold changed. The Mongo-backed integration suites in this environment fail a different disjoint set on each run and pass in isolation on unmodified code, so the unit path was used for proof.

## Follow-up, not fixed here

`acquireLock` in `lib/services/distributedLock.js` validates `ttlMs` but not `name` — the asymmetry that let the reproduction succeed. Closing it there would protect every future caller, not just `bootstrapCron`, but `distributedLock.js` is shared infrastructure outside this issue's scope.

Closes #3997

https://claude.ai/code/session_0185ELiCjZaBJx8PH4xoSsZb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized billing scheduled tasks on shared startup and configuration handling.
  * Preserved existing billing sweep, reconciliation, expiration, referral, and reset behavior, including locking and feature gates.

* **Tests**
  * Added coverage for shared startup validation, configuration gates, environment defaults, service setup, and lock settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->